### PR TITLE
Remove duplicate typedef declarations.

### DIFF
--- a/include/urweb/types_cpp.h
+++ b/include/urweb/types_cpp.h
@@ -130,7 +130,12 @@ typedef struct uw_Sqlcache_Value {
   unsigned long timeValid;
 } uw_Sqlcache_Value;
 
-typedef struct uw_Sqlcache_Entry uw_Sqlcache_Entry;
+typedef struct uw_Sqlcache_Entry {
+  char *key;
+  uw_Sqlcache_Value *value;
+  unsigned long timeInvalid;
+  UT_hash_handle hh;
+} uw_Sqlcache_Entry;
 
 typedef struct uw_Sqlcache_Cache {
   pthread_rwlock_t lockOut;

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -4562,13 +4562,6 @@ void uw_set_remoteSock(uw_context ctx, int sock) {
 
 // Sqlcache
 
-typedef struct uw_Sqlcache_Entry {
-  char *key;
-  uw_Sqlcache_Value *value;
-  unsigned long timeInvalid;
-  UT_hash_handle hh;
-} uw_Sqlcache_Entry;
-
 static void uw_Sqlcache_freeValue(uw_Sqlcache_Value *value) {
   if (value) {
     free(value->result);


### PR DESCRIPTION
An attempt to fix #3. @JasonGross should probably try this before merging.