### PR TITLE
Streamline callout to emacs for HTML rendering.

### DIFF
--- a/src/demo.sml
+++ b/src/demo.sml
@@ -318,12 +318,13 @@ fun make' {prefix, dirname, guided} =
                                                              Posix.FileSys.ST.mtime htmlSt)
                                                  end handle OS.SysErr _ => true
 
-                                             val cmd = "emacs --eval \"(progn "
+                                             val cmd = "emacs -no-init-file --eval \"(progn "
                                                        ^ "(global-font-lock-mode t) "
                                                        ^ "(add-to-list 'load-path \\\""
                                                        ^ !Settings.configSitelisp
                                                        ^ "/\\\") "
                                                        ^ "(load \\\"urweb-mode-startup\\\") "
+                                                       ^ "(load \\\"htmlize\\\") "
                                                        ^ "(urweb-mode) "
                                                        ^ "(find-file \\\""
                                                        ^ src


### PR DESCRIPTION
My .emacs loads too many other things. Startup is slow and multiple invocations of emacs do not play together well (e.g. desktop-save-mode). 