### PR TITLE
urweb-mode: do not configure require-final-newline

### DIFF
--- a/src/elisp/urweb-mode.el
+++ b/src/elisp/urweb-mode.el
@@ -395,7 +395,6 @@ This mode runs `urweb-mode-hook' just before exiting.
   ;; Treat paragraph-separators in comments as paragraph-separators.
   (set (make-local-variable 'paragraph-separate)
        (concat "\\([ \t]*\\*)?\\)?\\(" paragraph-separate "\\)"))
-  (set (make-local-variable 'require-final-newline) t)
   ;; forward-sexp-function is an experimental variable in my hacked Emacs.
   (set (make-local-variable 'forward-sexp-function) 'urweb-user-forward-sexp)
   ;; For XEmacs


### PR DESCRIPTION
Ur/Web source files do not require a final newline. Thus,
require-final-newline is a personal setting and should not be configured
in the major mode. Setting it here will also negatively impact helpers
like ethan-wspace.