### PR TITLE
Fix for "normalizeTable" nesting thead and tfoot in tbody

### DIFF
--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -879,10 +879,12 @@ function normalizeTable(table) {
             for (script = table.firstChild; script && script != tbody; script = next) {
                 next = script.nextSibling;
 
-                if (firstChild)
-                    tbody.insertBefore(script, firstChild);
-                else
-                    tbody.appendChild(script);
+                if (script.tagName === "SCRIPT") {
+                    if (firstChild)
+                        tbody.insertBefore(script, firstChild);
+                    else
+                        tbody.appendChild(script);
+                }
             }
 
             return;

--- a/tests/normalizeTable.ur
+++ b/tests/normalizeTable.ur
@@ -1,0 +1,50 @@
+fun main () =
+visible <- source True;
+return
+    <xml>
+      <body>
+	<section>
+	  <h1>Static table</h1>
+	  <table border=1>
+	    <thead>
+	      <tr>
+		<th>Column 0</th>
+		<th>Column 1</th>
+	      </tr>
+	    </thead>
+	    <tbody>
+	      <tr>
+		<td>A</td>
+		<td>B</td>
+	      </tr>
+	    </tbody>
+	  </table>
+	</section>
+
+	<section>
+	  <h1>Dynamic table</h1>
+	  <table border=1>
+	    <thead>
+	      <tr>
+		<th>Column 0</th>
+		<th>Column 1</th>
+	      </tr>
+	    </thead>
+	    <tbody>
+	      <dyn signal={
+		 visible <- signal visible;
+		 return (if visible then
+			     <xml>
+			       <tr>
+			       <td>A</td>
+			       <td>B</td>
+			       </tr>			       
+			     </xml>
+			 else
+			     <xml></xml>)
+	      }/>
+	    </tbody>
+	  </table>
+	</section>
+      </body>
+    </xml>

--- a/tests/normalizeTable.urp
+++ b/tests/normalizeTable.urp
@@ -1,0 +1,1 @@
+normalizeTable

--- a/tests/normalizeTable.urs
+++ b/tests/normalizeTable.urs
@@ -1,0 +1,1 @@
+val main: unit -> transaction page


### PR DESCRIPTION
I believe that there is a bug in the normalizeTable function. Apparently, this function supposes that every child of a table is a tbody or is a script. This is not true, because thead and tfoot can also be children of a table. This pull request contains a fix for this bug and a small test that shows the bug happening. Without the fix, the header of the static table is different from the header of the dynamic table (see https://snag.gy/7DbsHi.jpg). With the fix applied, the headers look like the same (see (https://snag.gy/2R60b1.jpg).