### PR TITLE
Use 1s precision when comparing file mtimes

### DIFF
--- a/src/fileio.sml
+++ b/src/fileio.sml
@@ -3,9 +3,14 @@ structure FileIO :> FILE_IO = struct
 val mostRecentModTimeRef = ref (Time.zeroTime)
 
 fun checkFileModTime fname =
-  let val mtime = OS.FileSys.modTime fname in
-      if Time.compare (mtime, !mostRecentModTimeRef) = GREATER andalso
-         Time.compare (mtime, Globals.getResetTime ()) = LESS
+  let
+      val mtime = OS.FileSys.modTime fname
+      val mostRecentMod = !mostRecentModTimeRef
+      val resetTime = Globals.getResetTime ()
+      fun lessThan (a, b) = LargeInt.compare (Time.toSeconds a, Time.toSeconds b) = LESS
+      infix lessThan
+  in
+      if mostRecentMod lessThan mtime andalso mtime lessThan resetTime
       then mostRecentModTimeRef := mtime
       else ()
   end


### PR DESCRIPTION
HTTP Last-Modified caching depends on mtimes of files read during
compilation. Only mtimes before the compiler's start (reset) time are
considered. On filesystems with lower mtime precision than Standard
ML's Time.now, a temporary file generated by the compiler may have an
mtime preceding the reset time even though it was modified after. The
fix here is to compare times using 1s precision, the most granular
used by filesystems.