### PR TITLE
Add a -dynamic option and make static linking of the urweb libs the default.

### DIFF
--- a/src/compiler.sml
+++ b/src/compiler.sml
@@ -1527,8 +1527,10 @@ fun compileC {cname, oname, ename, libs, profile, debug, linker, link = link'} =
                       !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^ !Settings.configLib ^ "/liburweb.a"
                   else if Settings.getStaticLinking () then
                       " -static " ^ !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^ !Settings.configLib ^ "/liburweb.a"
-                  else
+                  else if Settings.getDynamicLinking () then
                       "-L" ^ !Settings.configLib ^ " " ^ #linkDynamic proto ^ " -lurweb"
+                  else
+                      !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^ !Settings.configLib ^ "/liburweb.a"
 
         val opt = if debug then
                       ""

--- a/src/main.mlton.sml
+++ b/src/main.mlton.sml
@@ -140,6 +140,9 @@ fun oneRun args =
               | "-static" :: rest =>
                 (Settings.setStaticLinking true;
                  doArgs rest)
+              | "-dynamic" :: rest =>
+                (Settings.setDynamicLinking true;
+                 doArgs rest)
               | "-stop" :: phase :: rest =>
                 (Compiler.setStop phase;
                  doArgs rest)

--- a/src/settings.sig
+++ b/src/settings.sig
@@ -243,6 +243,9 @@ signature SETTINGS = sig
     val setStaticLinking : bool -> unit
     val getStaticLinking : unit -> bool
 
+    val setDynamicLinking : bool -> unit
+    val getDynamicLinking : unit -> bool
+
     val setBootLinking : bool -> unit
     val getBootLinking : unit -> bool
 

--- a/src/settings.sml
+++ b/src/settings.sml
@@ -706,6 +706,10 @@ val staticLinking = ref false
 fun setStaticLinking b = staticLinking := b
 fun getStaticLinking () = !staticLinking
 
+val dynamicLinking = ref false
+fun setDynamicLinking b = dynamicLinking := b
+fun getDynamicLinking () = !dynamicLinking
+
 val bootLinking = ref false
 fun setBootLinking b = bootLinking := b
 fun getBootLinking () = !bootLinking


### PR DESCRIPTION
After looking through the code, it seems to me that the default link mode of dynamic external and static internal linking mentioned in issue #44 is exactly the "-boot" link mode already present.
