### PR TITLE
Allow outputting JS code to a specified file

### DIFF
--- a/src/cjr_print.sml
+++ b/src/cjr_print.sml
@@ -2513,8 +2513,12 @@ fun p_decl env (dAll as (d, loc) : decl) =
 
       | DJavaScript s =>
         let
+	    val name =
+		(case Settings.getOutputJsFile () of
+		    NONE => "app." ^ SHA1.bintohex (SHA1.hash s) ^ ".js"
+		  | SOME s => s)
             val () = app_js := OS.Path.joinDirFile {dir = Settings.getUrlPrefix (),
-                                                    file = "app." ^ SHA1.bintohex (SHA1.hash s) ^ ".js"}
+                                                    file = name}
         in
             box [string "static char jslib[] = \"",
                  string (Prim.toCString s),

--- a/src/main.mlton.sml
+++ b/src/main.mlton.sml
@@ -134,6 +134,9 @@ fun oneRun args =
               | "-output" :: s :: rest =>
                 (Settings.setExe (SOME s);
                  doArgs rest)
+              | "-js" :: s :: rest =>
+		(Settings.setOutputJsFile (SOME s);
+		 doArgs rest)
               | "-sql" :: s :: rest =>
                 (Settings.setSql (SOME s);
                  doArgs rest)

--- a/src/settings.sig
+++ b/src/settings.sig
@@ -303,4 +303,6 @@ signature SETTINGS = sig
     val addJsFile : string (* filename *) -> unit
     val listJsFiles : unit -> {Filename : string, Content : string} list
 
+    val setOutputJsFile : string option (* filename *) -> unit
+    val getOutputJsFile : unit -> string option
 end

--- a/src/settings.sml
+++ b/src/settings.sml
@@ -951,6 +951,10 @@ fun addJsFile LoadFromFilename =
 
 fun listJsFiles () = SM.listItems (!jsFiles)
 
+val jsOutput = ref (NONE : string option)
+fun setOutputJsFile so = jsOutput := so
+fun getOutputJsFile () = !jsOutput
+
 fun reset () =
     (Globals.setResetTime ();
      urlPrefixFull := "/";
@@ -996,6 +1000,7 @@ fun reset () =
      mimeTypes := NONE;
      files := SM.empty;
      jsFiles := SM.empty;
-     filePath := ".")
+     filePath := ".";
+     jsOutput := NONE)
 
 end


### PR DESCRIPTION
Currently, the compiler will create an "app.*.js" (where * is a hash value) file for outputting generated JS code. User has really no control over the filename, but it is sometimes useful to have.

This adds a `-js` parameter that allows user to specify what file to write the generated JS code to.