### PR TITLE
Mark accepted sockets with CLOEXEC flag

### DIFF
--- a/include/urweb/urweb_cpp.h
+++ b/include/urweb/urweb_cpp.h
@@ -2,11 +2,13 @@
 #define URWEB_CPP_H
 
 #include <sys/types.h>
+#include <sys/socket.h>
 
 #include "types_cpp.h"
 
 int uw_really_send(int sock, const void *buf, ssize_t len);
 int uw_really_write(int fd, const void *buf, size_t len);
+int uw_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 
 extern uw_unit uw_unit_v;
 

--- a/src/c/fastcgi.c
+++ b/src/c/fastcgi.c
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 #include <unistd.h>
 #include <signal.h>
+#include <fcntl.h>
 #include <stdarg.h>
 #include <ctype.h>
 
@@ -566,7 +567,7 @@ int main(int argc, char *argv[]) {
   socklen_t sin_size;
   int nthreads = 1, i, *names, opt;
   char *fwsa = getenv("FCGI_WEB_SERVER_ADDRS"), *nthreads_s = getenv("URWEB_NUM_THREADS");
- 
+
   if (nthreads_s) {
     nthreads = atoi(nthreads_s);
     if (nthreads <= 0) {
@@ -627,7 +628,7 @@ int main(int argc, char *argv[]) {
   }
 
   for (i = 0; i < nthreads; ++i) {
-    pthread_t thread;    
+    pthread_t thread;
     names[i] = i;
     if (pthread_create_big(&thread, NULL, worker, &names[i])) {
       fprintf(stderr, "Error creating worker thread #%d\n", i);
@@ -636,7 +637,7 @@ int main(int argc, char *argv[]) {
   }
 
   while (1) {
-    int new_fd = accept(FCGI_LISTENSOCK_FILENO, (struct sockaddr *)&their_addr, &sin_size);
+    int new_fd = uw_accept(FCGI_LISTENSOCK_FILENO, (struct sockaddr *)&their_addr, &sin_size);
 
     if (new_fd < 0) {
       fprintf(stderr, "Socket accept failed\n");

--- a/src/c/http.c
+++ b/src/c/http.c
@@ -9,6 +9,7 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdarg.h>
 
@@ -500,7 +501,7 @@ int main(int argc, char *argv[]) {
   }
 
   for (i = 0; i < nthreads; ++i) {
-    pthread_t thread;    
+    pthread_t thread;
     names[i] = i;
     if (pthread_create_big(&thread, NULL, worker, &names[i])) {
       fprintf(stderr, "Error creating worker thread #%d\n", i);
@@ -509,7 +510,7 @@ int main(int argc, char *argv[]) {
   }
 
   while (1) {
-    int new_fd = accept(sockfd, &their_addr.sa, &sin_size);
+    int new_fd = uw_accept(sockfd, &their_addr.sa, &sin_size);
 
     if (new_fd < 0) {
       qfprintf(stderr, "Socket accept failed\n");
@@ -517,7 +518,7 @@ int main(int argc, char *argv[]) {
       qprintf("Accepted connection.\n");
 
       if (keepalive) {
-        int flag = 1; 
+        int flag = 1;
         setsockopt(new_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int));
       }
 


### PR DESCRIPTION
This measure prevents sockets from leaking to child processes launched by
application (via FFI libraries).