### PR TITLE
Fix for non-working '-m' runtime option

### DIFF
--- a/src/c/http.c
+++ b/src/c/http.c
@@ -359,7 +359,7 @@ int main(int argc, char *argv[]) {
   my_addr.sa.sa_family = AF_INET;
   my_addr.ipv4.sin_addr.s_addr = INADDR_ANY; // auto-fill with my IP
 
-  while ((opt = getopt(argc, argv, "hp:a:A:t:kqT:")) != -1) {
+  while ((opt = getopt(argc, argv, "hp:a:A:t:kqT:m:")) != -1) {
     switch (opt) {
     case '?':
       fprintf(stderr, "Unknown command-line option\n");


### PR DESCRIPTION
Added forgotten `"m:"` to `getopt()`