### PR TITLE
Option to prefix all user JavaScript FFI functions with a module name

### DIFF
--- a/src/compiler.sig
+++ b/src/compiler.sig
@@ -48,6 +48,7 @@ signature COMPILER = sig
          benignEffectful : Settings.ffi list,
          clientOnly : Settings.ffi list,
          serverOnly : Settings.ffi list,
+         jsModule : string option,
          jsFuncs : (Settings.ffi * string) list,
          rewrites : Settings.rewrite list,
          filterUrl : Settings.rule list,

--- a/src/demo.sml
+++ b/src/demo.sml
@@ -16,7 +16,7 @@
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
@@ -111,6 +111,7 @@ fun make' {prefix, dirname, guided} =
             benignEffectful = [],
             clientOnly = [],
             serverOnly = [],
+            jsModule = NONE,
             jsFuncs = [],
             rewrites = #rewrites combined @ #rewrites urp,
             filterUrl = #filterUrl combined @ #filterUrl urp,
@@ -280,7 +281,7 @@ fun make' {prefix, dirname, guided} =
                             val (urpData, out) = startUrp urp
                         in
                             finished ();
-                            
+
                             SOME (readUrp (urpData,
                                            out))
                         end
@@ -399,7 +400,7 @@ fun make' {prefix, dirname, guided} =
                              case #kind rule of
                                  Settings.Exact => ()
                                | Settings.Prefix => TextIO.output (outf, "*");
-                             TextIO.output (outf, "\n")))                  
+                             TextIO.output (outf, "\n")))
             in
                 Option.app (fn db => (TextIO.output (outf, "database ");
                                       TextIO.output (outf, db);

--- a/src/settings.sig
+++ b/src/settings.sig
@@ -96,6 +96,7 @@ signature SETTINGS = sig
     val isServerOnly : ffi -> bool
 
     (* Which FFI functions may be run in JavaScript?  (JavaScript function names included) *)
+    val setJsModule : string option -> unit
     val setJsFuncs : (ffi * string) list -> unit
     val addJsFunc : ffi * string -> unit
     val jsFunc : ffi -> string option

--- a/src/settings.sml
+++ b/src/settings.sml
@@ -346,7 +346,7 @@ val jsFuncsBase = basisM [("alert", "alert"),
                           ("asin", "asin"),
                           ("acos", "acos"),
                           ("atan", "atan"),
-                          ("atan2", "atan2"),                           
+                          ("atan2", "atan2"),
                           ("abs", "abs"),
 
                           ("now", "now"),
@@ -395,9 +395,15 @@ val jsFuncsBase = basisM [("alert", "alert"),
                           ("htmlifySpecialChar", "htmlifySpecialChar"),
                           ("chr", "chr")]
 val jsFuncs = ref jsFuncsBase
-fun setJsFuncs ls = jsFuncs := foldl (fn ((k, v), m) => M.insert (m, k, v)) jsFuncsBase ls
+val jsModule = ref NONE
+fun setJsModule m = jsModule := m
+fun jsFuncName f =
+    case !jsModule of
+        SOME m => m ^ "." ^ f
+      | NONE => f
+fun setJsFuncs ls = jsFuncs := foldl (fn ((k, v), m) => M.insert (m, k, jsFuncName v)) jsFuncsBase ls
 fun jsFunc x = M.find (!jsFuncs, x)
-fun addJsFunc (k, v) = jsFuncs := M.insert (!jsFuncs, k, v)
+fun addJsFunc (k, v) = jsFuncs := M.insert (!jsFuncs, k, jsFuncName v)
 fun allJsFuncs () = M.listItemsi (!jsFuncs)
 
 datatype pattern_kind = Exact | Prefix


### PR DESCRIPTION
Place
```
jsModule myModule
```
to .urp file.

And all `jsFunc` and `ffi` declaration will be automatically prefixed with `myModule` (e.g. `jsFunc UrModule.ident=func` and `ffi func` will become `myModule.func` in JavaScript).

Some background. More than once my users had problems with some bad browser extensions overwriting some of my utility functions so I decided to move them into module (plus I've started splitting my large utils.js to modules and using webpack module binder).

So I needed a way for Ur/Web to call JS functions from module. One way was to prefix all `jsFunc` declarations and add `jsFunc "myModule...."` to all `ffi` declarations and another way was to add this option.