### PR TITLE
Added instruction for executing autogen before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ demo/hello.exe &
 wget http://localhost:8080/Hello/main -O -
 ```
 
+# Generate Build Files
+
+```sh
+./autogen
+```
+
 # Simple Installation
 
 The normal UNIX-style build and installation procedure works.


### PR DESCRIPTION
Hello,

In order to build and install from repository code and not the release version, the first step is ideally to run the `autogen` file. The readme documentation can be more expressive by adding that statement. Right now, I had to dig deep into the mailing list discussion here -
http://www.impredicative.com/pipermail/ur/2013-November/001507.html

I went ahead and added a step in the ReadMe file. Let me know what you think!

Thanks,
Harshita