### PR TITLE
Mention that crypt uses DES-based scheme

### DIFF
--- a/lib/ur/basis.urs
+++ b/lib/ur/basis.urs
@@ -195,6 +195,7 @@ val datetimeDayOfWeek : time -> int
 (** * Encryption *)
 
 val crypt : string -> string -> string
+(* Uses a DES-based hashing scheme which clips the secret to 8 characters. *)
 
 
 (** HTTP operations *)


### PR DESCRIPTION
DES is considered pretty insecure by today's standards and it discards any character after the eighth. I think it'd be good to at least mention this in a comment so that users can make an informed decision
when implementing authentication, since changing the algorithm would break existing code as mentioned in #20.