### PR TITLE
Use morphdom to apply dom changes in dyn nodes

### DIFF
--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -1,3 +1,687 @@
+// VENDORING MORPHDOM: https://github.com/patrick-steele-idem/morphdom
+var morphdom = (function(){
+  var range; // Create a range object for efficently rendering strings to elements.
+  var NS_XHTML = 'http://www.w3.org/1999/xhtml';
+
+  var doc = typeof document === 'undefined' ? undefined : document;
+
+  var testEl = doc ?
+      doc.body || doc.createElement('div') :
+      {};
+
+  // Fixes <https://github.com/patrick-steele-idem/morphdom/issues/32>
+  // (IE7+ support) <=IE7 does not support el.hasAttribute(name)
+  var actualHasAttributeNS;
+
+  if (testEl.hasAttributeNS) {
+      actualHasAttributeNS = function(el, namespaceURI, name) {
+          return el.hasAttributeNS(namespaceURI, name);
+      };
+  } else if (testEl.hasAttribute) {
+      actualHasAttributeNS = function(el, namespaceURI, name) {
+          return el.hasAttribute(name);
+      };
+  } else {
+      actualHasAttributeNS = function(el, namespaceURI, name) {
+          return el.getAttributeNode(namespaceURI, name) != null;
+      };
+  }
+
+  var hasAttributeNS = actualHasAttributeNS;
+
+
+  function toElement(str) {
+      if (!range && doc.createRange) {
+          range = doc.createRange();
+          range.selectNode(doc.body);
+      }
+
+      var fragment;
+      if (range && range.createContextualFragment) {
+          fragment = range.createContextualFragment(str);
+      } else {
+          fragment = doc.createElement('body');
+          fragment.innerHTML = str;
+      }
+      return fragment.childNodes[0];
+  }
+
+  /**
+  * Returns true if two node's names are the same.
+  *
+  * NOTE: We don't bother checking `namespaceURI` because you will never find two HTML elements with the same
+  *       nodeName and different namespace URIs.
+  *
+  * @param {Element} a
+  * @param {Element} b The target element
+  * @return {boolean}
+  */
+  function compareNodeNames(fromEl, toEl) {
+      var fromNodeName = fromEl.nodeName;
+      var toNodeName = toEl.nodeName;
+
+      if (fromNodeName === toNodeName) {
+          return true;
+      }
+
+      if (toEl.actualize &&
+          fromNodeName.charCodeAt(0) < 91 && /* from tag name is upper case */
+          toNodeName.charCodeAt(0) > 90 /* target tag name is lower case */) {
+          // If the target element is a virtual DOM node then we may need to normalize the tag name
+          // before comparing. Normal HTML elements that are in the "http://www.w3.org/1999/xhtml"
+          // are converted to upper case
+          return fromNodeName === toNodeName.toUpperCase();
+      } else {
+          return false;
+      }
+  }
+
+  /**
+  * Create an element, optionally with a known namespace URI.
+  *
+  * @param {string} name the element name, e.g. 'div' or 'svg'
+  * @param {string} [namespaceURI] the element's namespace URI, i.e. the value of
+  * its `xmlns` attribute or its inferred namespace.
+  *
+  * @return {Element}
+  */
+  function createElementNS(name, namespaceURI) {
+      return !namespaceURI || namespaceURI === NS_XHTML ?
+          doc.createElement(name) :
+          doc.createElementNS(namespaceURI, name);
+  }
+
+  /**
+  * Copies the children of one DOM element to another DOM element
+  */
+  function moveChildren(fromEl, toEl) {
+      var curChild = fromEl.firstChild;
+      while (curChild) {
+          var nextChild = curChild.nextSibling;
+          toEl.appendChild(curChild);
+          curChild = nextChild;
+      }
+      return toEl;
+  }
+
+  function morphAttrs(fromNode, toNode) {
+      var attrs = toNode.attributes;
+      var i;
+      var attr;
+      var attrName;
+      var attrNamespaceURI;
+      var attrValue;
+      var fromValue;
+
+      for (i = attrs.length - 1; i >= 0; --i) {
+          attr = attrs[i];
+          attrName = attr.name;
+          attrNamespaceURI = attr.namespaceURI;
+          attrValue = attr.value;
+
+          if (attrNamespaceURI) {
+              attrName = attr.localName || attrName;
+              fromValue = fromNode.getAttributeNS(attrNamespaceURI, attrName);
+
+              if (fromValue !== attrValue) {
+                  fromNode.setAttributeNS(attrNamespaceURI, attrName, attrValue);
+              }
+          } else {
+              fromValue = fromNode.getAttribute(attrName);
+
+              if (fromValue !== attrValue) {
+                  fromNode.setAttribute(attrName, attrValue);
+              }
+          }
+      }
+
+      // Remove any extra attributes found on the original DOM element that
+      // weren't found on the target element.
+      attrs = fromNode.attributes;
+
+      for (i = attrs.length - 1; i >= 0; --i) {
+          attr = attrs[i];
+          if (attr.specified !== false) {
+              attrName = attr.name;
+              attrNamespaceURI = attr.namespaceURI;
+
+              if (attrNamespaceURI) {
+                  attrName = attr.localName || attrName;
+
+                  if (!hasAttributeNS(toNode, attrNamespaceURI, attrName)) {
+                      fromNode.removeAttributeNS(attrNamespaceURI, attrName);
+                  }
+              } else {
+                  if (!hasAttributeNS(toNode, null, attrName)) {
+                      fromNode.removeAttribute(attrName);
+                  }
+              }
+          }
+      }
+  }
+
+  function syncBooleanAttrProp(fromEl, toEl, name) {
+      if (fromEl[name] !== toEl[name]) {
+          fromEl[name] = toEl[name];
+          if (fromEl[name]) {
+              fromEl.setAttribute(name, '');
+          } else {
+              fromEl.removeAttribute(name, '');
+          }
+      }
+  }
+
+  var specialElHandlers = {
+      /**
+      * Needed for IE. Apparently IE doesn't think that "selected" is an
+      * attribute when reading over the attributes using selectEl.attributes
+      */
+      OPTION: function(fromEl, toEl) {
+          syncBooleanAttrProp(fromEl, toEl, 'selected');
+      },
+      /**
+      * The "value" attribute is special for the <input> element since it sets
+      * the initial value. Changing the "value" attribute without changing the
+      * "value" property will have no effect since it is only used to the set the
+      * initial value.  Similar for the "checked" attribute, and "disabled".
+      */
+      INPUT: function(fromEl, toEl) {
+          syncBooleanAttrProp(fromEl, toEl, 'checked');
+          syncBooleanAttrProp(fromEl, toEl, 'disabled');
+
+          if (fromEl.value !== toEl.value) {
+              fromEl.value = toEl.value;
+          }
+
+          if (!hasAttributeNS(toEl, null, 'value')) {
+              fromEl.removeAttribute('value');
+          }
+      },
+
+      TEXTAREA: function(fromEl, toEl) {
+          var newValue = toEl.value;
+          if (fromEl.value !== newValue) {
+              fromEl.value = newValue;
+          }
+
+          var firstChild = fromEl.firstChild;
+          if (firstChild) {
+              // Needed for IE. Apparently IE sets the placeholder as the
+              // node value and vise versa. This ignores an empty update.
+              var oldValue = firstChild.nodeValue;
+
+              if (oldValue == newValue || (!newValue && oldValue == fromEl.placeholder)) {
+                  return;
+              }
+
+              firstChild.nodeValue = newValue;
+          }
+      },
+      SELECT: function(fromEl, toEl) {
+          if (!hasAttributeNS(toEl, null, 'multiple')) {
+              var selectedIndex = -1;
+              var i = 0;
+              var curChild = toEl.firstChild;
+              while(curChild) {
+                  var nodeName = curChild.nodeName;
+                  if (nodeName && nodeName.toUpperCase() === 'OPTION') {
+                      if (hasAttributeNS(curChild, null, 'selected')) {
+                          selectedIndex = i;
+                          break;
+                      }
+                      i++;
+                  }
+                  curChild = curChild.nextSibling;
+              }
+
+              fromEl.selectedIndex = i;
+          }
+      }
+  };
+
+  var ELEMENT_NODE = 1;
+  var TEXT_NODE = 3;
+  var COMMENT_NODE = 8;
+
+  function noop() {}
+
+  function defaultGetNodeKey(node) {
+      return node.id;
+  }
+
+  function morphdomFactory(morphAttrs) {
+
+      return function morphdom(fromNode, toNode, options) {
+          if (!options) {
+              options = {};
+          }
+
+          if (typeof toNode === 'string') {
+              if (fromNode.nodeName === '#document' || fromNode.nodeName === 'HTML') {
+                  var toNodeHtml = toNode;
+                  toNode = doc.createElement('html');
+                  toNode.innerHTML = toNodeHtml;
+              } else {
+                  toNode = toElement(toNode);
+              }
+          }
+
+          var getNodeKey = options.getNodeKey || defaultGetNodeKey;
+          var onBeforeNodeAdded = options.onBeforeNodeAdded || noop;
+          var onNodeAdded = options.onNodeAdded || noop;
+          var onBeforeElUpdated = options.onBeforeElUpdated || noop;
+          var onElUpdated = options.onElUpdated || noop;
+          var onBeforeNodeDiscarded = options.onBeforeNodeDiscarded || noop;
+          var onNodeDiscarded = options.onNodeDiscarded || noop;
+          var onBeforeElChildrenUpdated = options.onBeforeElChildrenUpdated || noop;
+          var childrenOnly = options.childrenOnly === true;
+
+          // This object is used as a lookup to quickly find all keyed elements in the original DOM tree.
+          var fromNodesLookup = {};
+          var keyedRemovalList;
+
+          function addKeyedRemoval(key) {
+              if (keyedRemovalList) {
+                  keyedRemovalList.push(key);
+              } else {
+                  keyedRemovalList = [key];
+              }
+          }
+
+          function walkDiscardedChildNodes(node, skipKeyedNodes) {
+              if (node.nodeType === ELEMENT_NODE) {
+                  var curChild = node.firstChild;
+                  while (curChild) {
+
+                      var key = undefined;
+
+                      if (skipKeyedNodes && (key = getNodeKey(curChild))) {
+                          // If we are skipping keyed nodes then we add the key
+                          // to a list so that it can be handled at the very end.
+                          addKeyedRemoval(key);
+                      } else {
+                          // Only report the node as discarded if it is not keyed. We do this because
+                          // at the end we loop through all keyed elements that were unmatched
+                          // and then discard them in one final pass.
+                          onNodeDiscarded(curChild);
+                          if (curChild.firstChild) {
+                              walkDiscardedChildNodes(curChild, skipKeyedNodes);
+                          }
+                      }
+
+                      curChild = curChild.nextSibling;
+                  }
+              }
+          }
+
+          /**
+          * Removes a DOM node out of the original DOM
+          *
+          * @param  {Node} node The node to remove
+          * @param  {Node} parentNode The nodes parent
+          * @param  {Boolean} skipKeyedNodes If true then elements with keys will be skipped and not discarded.
+          * @return {undefined}
+          */
+          function removeNode(node, parentNode, skipKeyedNodes) {
+              if (onBeforeNodeDiscarded(node) === false) {
+                  return;
+              }
+
+              if (parentNode) {
+                  parentNode.removeChild(node);
+              }
+
+              onNodeDiscarded(node);
+              walkDiscardedChildNodes(node, skipKeyedNodes);
+          }
+
+          // // TreeWalker implementation is no faster, but keeping this around in case this changes in the future
+          // function indexTree(root) {
+          //     var treeWalker = document.createTreeWalker(
+          //         root,
+          //         NodeFilter.SHOW_ELEMENT);
+          //
+          //     var el;
+          //     while((el = treeWalker.nextNode())) {
+          //         var key = getNodeKey(el);
+          //         if (key) {
+          //             fromNodesLookup[key] = el;
+          //         }
+          //     }
+          // }
+
+          // // NodeIterator implementation is no faster, but keeping this around in case this changes in the future
+          //
+          // function indexTree(node) {
+          //     var nodeIterator = document.createNodeIterator(node, NodeFilter.SHOW_ELEMENT);
+          //     var el;
+          //     while((el = nodeIterator.nextNode())) {
+          //         var key = getNodeKey(el);
+          //         if (key) {
+          //             fromNodesLookup[key] = el;
+          //         }
+          //     }
+          // }
+
+          function indexTree(node) {
+              if (node.nodeType === ELEMENT_NODE) {
+                  var curChild = node.firstChild;
+                  while (curChild) {
+                      var key = getNodeKey(curChild);
+                      if (key) {
+                          fromNodesLookup[key] = curChild;
+                      }
+
+                      // Walk recursively
+                      indexTree(curChild);
+
+                      curChild = curChild.nextSibling;
+                  }
+              }
+          }
+
+          indexTree(fromNode);
+
+          function handleNodeAdded(el) {
+              onNodeAdded(el);
+
+              var curChild = el.firstChild;
+              while (curChild) {
+                  var nextSibling = curChild.nextSibling;
+
+                  var key = getNodeKey(curChild);
+                  if (key) {
+                      var unmatchedFromEl = fromNodesLookup[key];
+                      if (unmatchedFromEl && compareNodeNames(curChild, unmatchedFromEl)) {
+                          curChild.parentNode.replaceChild(unmatchedFromEl, curChild);
+                          morphEl(unmatchedFromEl, curChild);
+                      }
+                  }
+
+                  handleNodeAdded(curChild);
+                  curChild = nextSibling;
+              }
+          }
+
+          function morphEl(fromEl, toEl, childrenOnly) {
+              var toElKey = getNodeKey(toEl);
+              var curFromNodeKey;
+
+              if (toElKey) {
+                  // If an element with an ID is being morphed then it is will be in the final
+                  // DOM so clear it out of the saved elements collection
+                  delete fromNodesLookup[toElKey];
+              }
+
+              if (toNode.isSameNode && toNode.isSameNode(fromNode)) {
+                  return;
+              }
+
+              if (!childrenOnly) {
+                  if (onBeforeElUpdated(fromEl, toEl) === false) {
+                      return;
+                  }
+
+                  morphAttrs(fromEl, toEl);
+                  onElUpdated(fromEl);
+
+                  if (onBeforeElChildrenUpdated(fromEl, toEl) === false) {
+                      return;
+                  }
+              }
+
+              if (fromEl.nodeName !== 'TEXTAREA') {
+                  var curToNodeChild = toEl.firstChild;
+                  var curFromNodeChild = fromEl.firstChild;
+                  var curToNodeKey;
+
+                  var fromNextSibling;
+                  var toNextSibling;
+                  var matchingFromEl;
+
+                  outer: while (curToNodeChild) {
+                      toNextSibling = curToNodeChild.nextSibling;
+                      curToNodeKey = getNodeKey(curToNodeChild);
+
+                      while (curFromNodeChild) {
+                          fromNextSibling = curFromNodeChild.nextSibling;
+
+                          if (curToNodeChild.isSameNode && curToNodeChild.isSameNode(curFromNodeChild)) {
+                              curToNodeChild = toNextSibling;
+                              curFromNodeChild = fromNextSibling;
+                              continue outer;
+                          }
+
+                          curFromNodeKey = getNodeKey(curFromNodeChild);
+
+                          var curFromNodeType = curFromNodeChild.nodeType;
+
+                          var isCompatible = undefined;
+
+                          if (curFromNodeType === curToNodeChild.nodeType) {
+                              if (curFromNodeType === ELEMENT_NODE) {
+                                  // Both nodes being compared are Element nodes
+
+                                  if (curToNodeKey) {
+                                      // The target node has a key so we want to match it up with the correct element
+                                      // in the original DOM tree
+                                      if (curToNodeKey !== curFromNodeKey) {
+                                          // The current element in the original DOM tree does not have a matching key so
+                                          // let's check our lookup to see if there is a matching element in the original
+                                          // DOM tree
+                                          if ((matchingFromEl = fromNodesLookup[curToNodeKey])) {
+                                              if (curFromNodeChild.nextSibling === matchingFromEl) {
+                                                  // Special case for single element removals. To avoid removing the original
+                                                  // DOM node out of the tree (since that can break CSS transitions, etc.),
+                                                  // we will instead discard the current node and wait until the next
+                                                  // iteration to properly match up the keyed target element with its matching
+                                                  // element in the original tree
+                                                  isCompatible = false;
+                                              } else {
+                                                  // We found a matching keyed element somewhere in the original DOM tree.
+                                                  // Let's moving the original DOM node into the current position and morph
+                                                  // it.
+
+                                                  // NOTE: We use insertBefore instead of replaceChild because we want to go through
+                                                  // the `removeNode()` function for the node that is being discarded so that
+                                                  // all lifecycle hooks are correctly invoked
+                                                  fromEl.insertBefore(matchingFromEl, curFromNodeChild);
+
+                                                  fromNextSibling = curFromNodeChild.nextSibling;
+
+                                                  if (curFromNodeKey) {
+                                                      // Since the node is keyed it might be matched up later so we defer
+                                                      // the actual removal to later
+                                                      addKeyedRemoval(curFromNodeKey);
+                                                  } else {
+                                                      // NOTE: we skip nested keyed nodes from being removed since there is
+                                                      //       still a chance they will be matched up later
+                                                      removeNode(curFromNodeChild, fromEl, true /* skip keyed nodes */);
+                                                  }
+
+                                                  curFromNodeChild = matchingFromEl;
+                                              }
+                                          } else {
+                                              // The nodes are not compatible since the "to" node has a key and there
+                                              // is no matching keyed node in the source tree
+                                              isCompatible = false;
+                                          }
+                                      }
+                                  } else if (curFromNodeKey) {
+                                      // The original has a key
+                                      isCompatible = false;
+                                  }
+
+                                  isCompatible = isCompatible !== false && compareNodeNames(curFromNodeChild, curToNodeChild);
+                                  if (isCompatible) {
+                                      // We found compatible DOM elements so transform
+                                      // the current "from" node to match the current
+                                      // target DOM node.
+                                      morphEl(curFromNodeChild, curToNodeChild);
+                                  }
+
+                              } else if (curFromNodeType === TEXT_NODE || curFromNodeType == COMMENT_NODE) {
+                                  // Both nodes being compared are Text or Comment nodes
+                                  isCompatible = true;
+                                  // Simply update nodeValue on the original node to
+                                  // change the text value
+                                  if (curFromNodeChild.nodeValue !== curToNodeChild.nodeValue) {
+                                      curFromNodeChild.nodeValue = curToNodeChild.nodeValue;
+                                  }
+
+                              }
+                          }
+
+                          if (isCompatible) {
+                              // Advance both the "to" child and the "from" child since we found a match
+                              curToNodeChild = toNextSibling;
+                              curFromNodeChild = fromNextSibling;
+                              continue outer;
+                          }
+
+                          // No compatible match so remove the old node from the DOM and continue trying to find a
+                          // match in the original DOM. However, we only do this if the from node is not keyed
+                          // since it is possible that a keyed node might match up with a node somewhere else in the
+                          // target tree and we don't want to discard it just yet since it still might find a
+                          // home in the final DOM tree. After everything is done we will remove any keyed nodes
+                          // that didn't find a home
+                          if (curFromNodeKey) {
+                              // Since the node is keyed it might be matched up later so we defer
+                              // the actual removal to later
+                              addKeyedRemoval(curFromNodeKey);
+                          } else {
+                              // NOTE: we skip nested keyed nodes from being removed since there is
+                              //       still a chance they will be matched up later
+                              removeNode(curFromNodeChild, fromEl, true /* skip keyed nodes */);
+                          }
+
+                          curFromNodeChild = fromNextSibling;
+                      }
+
+                      // If we got this far then we did not find a candidate match for
+                      // our "to node" and we exhausted all of the children "from"
+                      // nodes. Therefore, we will just append the current "to" node
+                      // to the end
+                      if (curToNodeKey && (matchingFromEl = fromNodesLookup[curToNodeKey]) && compareNodeNames(matchingFromEl, curToNodeChild)) {
+                          fromEl.appendChild(matchingFromEl);
+                          morphEl(matchingFromEl, curToNodeChild);
+                      } else {
+                          var onBeforeNodeAddedResult = onBeforeNodeAdded(curToNodeChild);
+                          if (onBeforeNodeAddedResult !== false) {
+                              if (onBeforeNodeAddedResult) {
+                                  curToNodeChild = onBeforeNodeAddedResult;
+                              }
+
+                              if (curToNodeChild.actualize) {
+                                  curToNodeChild = curToNodeChild.actualize(fromEl.ownerDocument || doc);
+                              }
+                              fromEl.appendChild(curToNodeChild);
+                              handleNodeAdded(curToNodeChild);
+                          }
+                      }
+
+                      curToNodeChild = toNextSibling;
+                      curFromNodeChild = fromNextSibling;
+                  }
+
+                  // We have processed all of the "to nodes". If curFromNodeChild is
+                  // non-null then we still have some from nodes left over that need
+                  // to be removed
+                  while (curFromNodeChild) {
+                      fromNextSibling = curFromNodeChild.nextSibling;
+                      if ((curFromNodeKey = getNodeKey(curFromNodeChild))) {
+                          // Since the node is keyed it might be matched up later so we defer
+                          // the actual removal to later
+                          addKeyedRemoval(curFromNodeKey);
+                      } else {
+                          // NOTE: we skip nested keyed nodes from being removed since there is
+                          //       still a chance they will be matched up later
+                          removeNode(curFromNodeChild, fromEl, true /* skip keyed nodes */);
+                      }
+                      curFromNodeChild = fromNextSibling;
+                  }
+              }
+
+              var specialElHandler = specialElHandlers[fromEl.nodeName];
+              if (specialElHandler) {
+                  specialElHandler(fromEl, toEl);
+              }
+          } // END: morphEl(...)
+
+          var morphedNode = fromNode;
+          var morphedNodeType = morphedNode.nodeType;
+          var toNodeType = toNode.nodeType;
+
+          if (!childrenOnly) {
+              // Handle the case where we are given two DOM nodes that are not
+              // compatible (e.g. <div> --> <span> or <div> --> TEXT)
+              if (morphedNodeType === ELEMENT_NODE) {
+                  if (toNodeType === ELEMENT_NODE) {
+                      if (!compareNodeNames(fromNode, toNode)) {
+                          onNodeDiscarded(fromNode);
+                          morphedNode = moveChildren(fromNode, createElementNS(toNode.nodeName, toNode.namespaceURI));
+                      }
+                  } else {
+                      // Going from an element node to a text node
+                      morphedNode = toNode;
+                  }
+              } else if (morphedNodeType === TEXT_NODE || morphedNodeType === COMMENT_NODE) { // Text or comment node
+                  if (toNodeType === morphedNodeType) {
+                      if (morphedNode.nodeValue !== toNode.nodeValue) {
+                          morphedNode.nodeValue = toNode.nodeValue;
+                      }
+
+                      return morphedNode;
+                  } else {
+                      // Text node to something else
+                      morphedNode = toNode;
+                  }
+              }
+          }
+
+          if (morphedNode === toNode) {
+              // The "to node" was not compatible with the "from node" so we had to
+              // toss out the "from node" and use the "to node"
+              onNodeDiscarded(fromNode);
+          } else {
+              morphEl(morphedNode, toNode, childrenOnly);
+
+              // We now need to loop over any keyed nodes that might need to be
+              // removed. We only do the removal if we know that the keyed node
+              // never found a match. When a keyed node is matched up we remove
+              // it out of fromNodesLookup and we use fromNodesLookup to determine
+              // if a keyed node has been matched up or not
+              if (keyedRemovalList) {
+                  for (var i=0, len=keyedRemovalList.length; i<len; i++) {
+                      var elToRemove = fromNodesLookup[keyedRemovalList[i]];
+                      if (elToRemove) {
+                          removeNode(elToRemove, elToRemove.parentNode, false);
+                      }
+                  }
+              }
+          }
+
+          if (!childrenOnly && morphedNode !== fromNode && fromNode.parentNode) {
+              if (morphedNode.actualize) {
+                  morphedNode = morphedNode.actualize(fromNode.ownerDocument || doc);
+              }
+              // If we had to swap out the from node with a new node because the old
+              // node was not compatible with the target node then we need to
+              // replace the old DOM node in the original DOM tree. This is only
+              // possible if the original DOM node was part of a DOM tree which
+              // we know is the case if it has a parent node.
+              fromNode.parentNode.replaceChild(morphedNode, fromNode);
+          }
+
+          return morphedNode;
+      };
+  }
+
+  return morphdomFactory(morphAttrs);
+}());
+
+
+
 // Detect browser quirks that we should be aware of.
 
 function needsDynPrefix() {

--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -1608,6 +1608,7 @@ function dyn(pnode, s) {
     if (suspendScripts)
         return;
 
+    // Marker script
     var x = document.createElement("script");
     x.dead = false;
     x.signal = s;
@@ -1630,9 +1631,6 @@ function dyn(pnode, s) {
                 for (var i = 0; i < arr.length; ++i)
                     killScript(arr[i]);
             }
-
-            if (child.parentNode)
-                child.parentNode.removeChild(child);
         }
 
         var cls = {v : null};
@@ -1640,95 +1638,50 @@ function dyn(pnode, s) {
         if (pnode != "table" && pnode != "tr")
             html = dynPrefix + html;
         x.closures = cls.v;
+        
+        if (!x.parentNode){return; }
 
-        if (pnode == "table") {
-            normalizeTable(x.parentNode);
+        if (pnode == "table" || pnode == "tr") {
+            if (pnode == "table")
+                normalizeTable(x.parentNode);
 
-            var dummy = document.createElement("body");
+            var parent = x.parentNode;
+
+            if (!firstChild){
+                firstChild = document.createElement("script");
+                parent.insertBefore(firstChild, x);
+            }
+
+            var dummy = document.createElement(parent.tagName);
             suspendScripts = true;
             try {
-                dummy.innerHTML = "<table>" + html + "</table>";
+                dummy.innerHTML = html;
             } catch (e) {
                 suspendScripts = false;
                 throw e;
             }
 
-            var table = x.parentNode;
+            var skipChildren = Array.prototype.indexOf.call(firstChild.parentNode.childNodes, firstChild) + 1; // + 1 because we want to skip the "firstChild" marker script
+            var skipChildrenEnd = x.parentNode.childNodes.length - Array.prototype.indexOf.call(x.parentNode.childNodes, x); // No -1 because we want to skip the "x" marker script
 
-            if (table) {
-                firstChild = null;
-                var tbody;
-
-                var arr = dummy.getElementsByTagName("tbody");
-
-                var tbody;
-                if (arr.length > 0 && arr[0].parentNode == dummy.firstChild) {
-                    tbody = arr[0];
-                    var next;
-                    for (var node = dummy.firstChild.firstChild; node; node = next) {
-                        next = node.nextSibling;
-
-                        if (node.tagName != "TBODY")
-                            tbody.appendChild(node);
-                    }
-                } else
-                    tbody = dummy.firstChild;
-
-                var next;
-                firstChild = document.createElement("script");
-                table.insertBefore(firstChild, x);
-                for (var node = tbody.firstChild; node; node = next) {
-                    next = node.nextSibling;
-                    table.insertBefore(node, x);
-                    suspendScripts = false;
-                    runScripts(node);
-                    suspendScripts = true;
-                }
-            }
+            morphdom(parent, dummy, {childrenOnly: true, skipChildren: skipChildren, skipChildrenEnd: skipChildrenEnd});
 
             suspendScripts = false;
-        } else if (pnode == "tr") {
-            var dummy = document.createElement("body");
-            suspendScripts = true;
-            try {
-                dummy.innerHTML = "<table><tr>" + html + "</tr></table>";
-            } catch (e) {
-                suspendScripts = false;
-                throw e;
-            }
-
-            var table = x.parentNode;
-
-            if (table) {
-                var arr = dummy.getElementsByTagName("tr");
-                firstChild = null;
-                var tr;
-                if (arr.length > 0 && table != null)
-                    tr = arr[0];
-                else
-                    tr = dummy.firstChild;
-
-                var next;
-                firstChild = document.createElement("script");
-                table.insertBefore(firstChild, x);
-                for (var node = tr.firstChild; node; node = next) {
-                    next = node.nextSibling;
-                    table.insertBefore(node, x);
-                    suspendScripts = false;
-                    runScripts(node);
-                    suspendScripts = true;
-                }
-            };
-
-            suspendScripts = false;
+            runScripts(dummy);
         } else {
-            firstChild = document.createElement("span");
-
             suspendScripts = true;
+            var dummy;
             try {
-                firstChild.innerHTML = html;
-                if (x.parentNode)
-                    x.parentNode.insertBefore(firstChild, x);
+              if (!firstChild){
+                  firstChild = document.createElement("span");
+                  firstChild.innerHTML = html;
+                  if (x.parentNode)
+                      x.parentNode.insertBefore(firstChild, x);
+              } else {
+                dummy = document.createElement("span");
+                dummy.innerHTML = html;
+                morphdom(firstChild, dummy, {childrenOnly: true});
+              }
             } catch (e) {
                 suspendScripts = false;
                 throw e;

--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -275,6 +275,8 @@ var morphdom = (function(){
           var onNodeDiscarded = options.onNodeDiscarded || noop;
           var onBeforeElChildrenUpdated = options.onBeforeElChildrenUpdated || noop;
           var childrenOnly = options.childrenOnly === true;
+          var skipChildren = options.skipChildren || 0;
+          var skipChildrenEnd = options.skipChildrenEnd || 0;
 
           // This object is used as a lookup to quickly find all keyed elements in the original DOM tree.
           var fromNodesLookup = {};
@@ -363,10 +365,15 @@ var morphdom = (function(){
           //     }
           // }
 
-          function indexTree(node) {
+          function indexTree(node, skipChildrenI, skipChildrenEndI) {
+              var skipChildren = skipChildrenI || 0;
+              var skipChildrenEnd = skipChildrenEndI || 0;
+
               if (node.nodeType === ELEMENT_NODE) {
-                  var curChild = node.firstChild;
-                  while (curChild) {
+                  var curChild = node.childNodes[skipChildren];
+                  var endingChild = node.childNodes[node.childNodes.length - skipChildrenEnd];
+                  var i = 0;
+                  while (curChild && curChild !== endingChild) {
                       var key = getNodeKey(curChild);
                       if (key) {
                           fromNodesLookup[key] = curChild;
@@ -380,7 +387,7 @@ var morphdom = (function(){
               }
           }
 
-          indexTree(fromNode);
+          indexTree(fromNode, skipChildren, skipChildrenEnd);
 
           function handleNodeAdded(el) {
               onNodeAdded(el);
@@ -403,9 +410,13 @@ var morphdom = (function(){
               }
           }
 
-          function morphEl(fromEl, toEl, childrenOnly) {
+          function morphEl(fromEl, toEl, childrenOnly, skipChildrenI, skipChildrenEndI) {
               var toElKey = getNodeKey(toEl);
               var curFromNodeKey;
+              var skipChildren = skipChildrenI || 0;
+              var skipChildrenEnd = skipChildrenEndI || 0;
+
+              var endingFromNodeChild = fromEl.childNodes[fromEl.childNodes.length - skipChildrenEnd];
 
               if (toElKey) {
                   // If an element with an ID is being morphed then it is will be in the final
@@ -432,7 +443,7 @@ var morphdom = (function(){
 
               if (fromEl.nodeName !== 'TEXTAREA') {
                   var curToNodeChild = toEl.firstChild;
-                  var curFromNodeChild = fromEl.firstChild;
+                  var curFromNodeChild = fromEl.childNodes[skipChildren];
                   var curToNodeKey;
 
                   var fromNextSibling;
@@ -443,7 +454,7 @@ var morphdom = (function(){
                       toNextSibling = curToNodeChild.nextSibling;
                       curToNodeKey = getNodeKey(curToNodeChild);
 
-                      while (curFromNodeChild) {
+                      while (curFromNodeChild && curFromNodeChild !== endingFromNodeChild) {
                           fromNextSibling = curFromNodeChild.nextSibling;
 
                           if (curToNodeChild.isSameNode && curToNodeChild.isSameNode(curFromNodeChild)) {
@@ -563,7 +574,11 @@ var morphdom = (function(){
                       // nodes. Therefore, we will just append the current "to" node
                       // to the end
                       if (curToNodeKey && (matchingFromEl = fromNodesLookup[curToNodeKey]) && compareNodeNames(matchingFromEl, curToNodeChild)) {
-                          fromEl.appendChild(matchingFromEl);
+                          if (skipChildrenEnd && endingFromNodeChild){
+                            fromEl.insertBefore(matchingFromEl, endingFromNodeChild);
+                          } else {
+                            fromEl.appendChild(matchingFromEl);
+                          }
                           morphEl(matchingFromEl, curToNodeChild);
                       } else {
                           var onBeforeNodeAddedResult = onBeforeNodeAdded(curToNodeChild);
@@ -575,7 +590,11 @@ var morphdom = (function(){
                               if (curToNodeChild.actualize) {
                                   curToNodeChild = curToNodeChild.actualize(fromEl.ownerDocument || doc);
                               }
-                              fromEl.appendChild(curToNodeChild);
+                              if (skipChildrenEnd && endingFromNodeChild){
+                                fromEl.insertBefore(curToNodeChild, endingFromNodeChild);
+                              } else {
+                                fromEl.appendChild(curToNodeChild);
+                              }
                               handleNodeAdded(curToNodeChild);
                           }
                       }
@@ -587,7 +606,7 @@ var morphdom = (function(){
                   // We have processed all of the "to nodes". If curFromNodeChild is
                   // non-null then we still have some from nodes left over that need
                   // to be removed
-                  while (curFromNodeChild) {
+                  while (curFromNodeChild && curFromNodeChild !== endingFromNodeChild) {
                       fromNextSibling = curFromNodeChild.nextSibling;
                       if ((curFromNodeKey = getNodeKey(curFromNodeChild))) {
                           // Since the node is keyed it might be matched up later so we defer
@@ -644,7 +663,7 @@ var morphdom = (function(){
               // toss out the "from node" and use the "to node"
               onNodeDiscarded(fromNode);
           } else {
-              morphEl(morphedNode, toNode, childrenOnly);
+              morphEl(morphedNode, toNode, childrenOnly, skipChildren, skipChildrenEnd);
 
               // We now need to loop over any keyed nodes that might need to be
               // removed. We only do the removal if we know that the keyed node
@@ -679,8 +698,6 @@ var morphdom = (function(){
 
   return morphdomFactory(morphAttrs);
 }());
-
-
 
 // Detect browser quirks that we should be aware of.
 


### PR DESCRIPTION
Regarding #113, I used morphdom to update dom changes in dyn nodes differently. Before this change, on every render of a dyn node we removed all dom nodes from the previous render and inserted all new nodes every time. This had some annoying effects, as described in the manual on page 47. The two coping strategies mentioned there are unnecessary after this change. After this change, dom updates will be done more intelligently, diffing the dom nodes from the previous render against the dom nodes of the current render (note: no virtual dom is used) and only applying the necessary dom updates incrementally.

I split the change into three commits for easier comparison.

The first commit vendors morphdom.js as is into urweb.js. I'm not sure if that's the best way but it made it easy to get started.

The second commit adds skipChildren and skipChildrenEnd options to morphdom. These are needed because morphdom takes one "before" node and one "after" node and changes one into the other. This is not how we want to do things when we add trs into tables or tds into trs, so we need to be able to say to morph dom "Here are two nodes, compare their children but skip the first x and last x children in the 'from' node".

The third commit then changes the recreate function to use morphdom for dom updating. I simplified the code a little in the process. Basically in the general case we add a span on the first render in which we render the html string. Next renders we make a new span every time, but the new html string in there, and then let morphdom change the first span to look like the new one. In the table/tr case we add a marker script on the first render, then render all the children in between that marker script and the script in the x variable, using morphdom to work out the differences.

Performance-wise I've found it hard to create and capture good benchmarks. In most cases where you're only rendering small amounts of nodes inside a dyn tag, the performance difference will be negligible. The more nodes that stay the same, the more performant this change is: We're creating the same amount of nodes, but only adding and removing what we need, which gives a good performance boost. For a simple benchmark where you can easily see the difference, make a page where you render 10000 elements in a dyn on every tick. The DOM has to do a ton more work before this change.

Phew, I hope this is OK. If you want me to do anything else or different, let me know. I know I've gone and made a PR without waiting for a reply from @achlipala in #113, but I was motivated to make this work. If you don't want to accept this, no hard feelings of course. But I do think this is a good change.

Further optimizations would be cutting out some code from the vendored morphdom code, since we're not using all of it's features. Also the code has quite a few comments etc so adds to the byte size, but I feel that's an orthogonal discussion that maybe belongs in #115.