### PR TITLE
Handling of JSON escape characters

### DIFF
--- a/lib/ur/json.ur
+++ b/lib/ur/json.ur
@@ -46,10 +46,14 @@ fun escape s =
                 let
                     val ch = String.sub s 0
                 in
-                    (if ch = #"\"" || ch = #"\\" then
-                         "\\" ^ String.str ch
-                     else
-                         String.str ch) ^ esc (String.suffix s 1)
+		    (case ch of
+			 #"\n" => "\\n"
+		       | #"\r" => "\\r"
+		       | #"\t" => "\\t"
+		       | #"\"" => "\\\""
+		       | #"\'" => "\\\'"
+		       | x => String.str ch
+		    ) ^ esc (String.suffix s 1)
                 end
     in
         "\"" ^ esc s
@@ -90,7 +94,15 @@ fun unescape s =
                         if i+1 >= len then
                             error <xml>JSON unescape: Bad escape sequence: {[s]}</xml>
                         else
-                            String.str (String.sub s (i+1)) ^ unesc (i+2)
+			    (case String.sub s (i+1) of
+				 #"n" => "\n"
+                               | #"r" => "\r"
+                               | #"t" => "\t"
+                               | #"\"" => "\""
+                               | #"\'" => "\'"
+                               | x => error <xml>JSON unescape: Bad escape char: {[x]}</xml>)
+			    ^
+			    unesc (i+2)
                       | _ => String.str ch ^ unesc (i+1)
                 end
     in

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -1,6 +1,7 @@
 open Json
 
 fun main () : transaction page = return <xml><body>
+  <pre>{[ fromJson "\"line 1\\nline 2\"" : string ]}</pre><br/>
   {[fromJson "[1, 2, 3]" : list int]}<br/>
   {[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}
 </body></xml>


### PR DESCRIPTION
1. Handle escape sequence chars
   \t \n \r

2. Fail on unsupported escape characters.

   Instead of skipping \ on unsupported sequences it now fails. 

I really need \n support everything else is extra.