### PR TITLE
Adding Selenium-based checking to tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ libtool
 include/urweb/config.h
 include/urweb/config.h.in
 include/urweb/stamp-h1
+
+# python files
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/tests/DynChannel.py
+++ b/tests/DynChannel.py
@@ -1,0 +1,20 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('DynChannel/main')
+
+        # initial state: only Register is visible
+        reg = self.xpath('button')
+        reg.click()
+        # and we get two another state: either Register or Send visible
+        send = self.xpath('span/button')
+        send.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Got something from the channel", alert.text)
+        alert.accept()
+        # we got the message back
+        span = self.xpath('span/span')
+        self.assertEqual("blabla", span.text)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,3 +19,4 @@ simple::
 	./driver.sh entities
 	./driver.sh fact
 	./driver.sh filter
+	./driver.sh jsbspace

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,3 +2,20 @@ all: test.o
 
 test.o: test.c
 	gcc -c test.c -o test.o
+###
+
+simple::
+	./driver.sh alert
+	./driver.sh align
+	./driver.sh appjs
+	./driver.sh ascdesc
+	echo ./driver.sh attrMangle
+	./driver.sh attrs_escape
+	echo ./driver.sh attrs
+	./driver.sh autocomp
+	./driver.sh bindpat
+	./driver.sh DynChannel
+	./driver.sh jsonTest
+	./driver.sh entities
+	./driver.sh fact
+	./driver.sh filter

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,13 @@ test.o: test.c
 ###
 
 simple::
+	./driver.sh aborter2
+	./driver.sh aborter
+	./driver.sh activeBlock
+	./driver.sh activeFocus
+	./driver.sh active
+	./driver.sh agg
+	./driver.sh ahead
 	./driver.sh alert
 	./driver.sh align
 	./driver.sh appjs
@@ -13,6 +20,7 @@ simple::
 	./driver.sh attrs_escape
 	echo ./driver.sh attrs
 	./driver.sh autocomp
+	./driver.sh babySpawn
 	./driver.sh bindpat
 	./driver.sh DynChannel
 	./driver.sh jsonTest

--- a/tests/aborter.py
+++ b/tests/aborter.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('Aborter/main')
+        self.assertEqual("Fatal Error", self.driver.title)
+        txt = self.body_text()
+        self.assertEqual("Fatal error: :0:0-0:0: No way, Jose!", txt)
+

--- a/tests/aborter.urp
+++ b/tests/aborter.urp
@@ -1,4 +1,5 @@
 database dbname=aborter
 sql aborter.sql
+safeGet Aborter/main
 
 aborter

--- a/tests/aborter2.py
+++ b/tests/aborter2.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('Aborter2/main')
+        self.assertEqual("", self.driver.title)
+        txt = self.body_text()
+        self.assertEqual("Result: 0", txt)
+

--- a/tests/active.py
+++ b/tests/active.py
@@ -1,0 +1,14 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        b1 = self.xpath('span[1]/button')
+        b2 = self.xpath('span[2]/button')
+        for _ in range(3):
+            b1.click()
+        for _ in range(5):
+            b2.click()
+        self.assertEqual("3\n5", self.body_text())

--- a/tests/activeBlock.py
+++ b/tests/activeBlock.py
@@ -1,0 +1,20 @@
+import unittest
+import base
+import time 
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Error: May not 'sleep' in main thread of 'code' for <active>", alert.text)
+        alert.accept()
+        time.sleep(0.1)
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Hi!", alert.text)
+        alert.accept()
+        button = self.xpath('span[1]/button')
+        button.click()
+        txt = self.body_text()
+        self.assertEqual("Hi! Click me! Success", txt)
+

--- a/tests/activeBlock.ur
+++ b/tests/activeBlock.ur
@@ -1,7 +1,7 @@
 fun main () : transaction page = return <xml><body>
   <active code={s <- source ""; return <xml>
     <dyn signal={s <- signal s; return (txt s)}/>
-    <button onclick={fn _ => set s "Hi!"}/>
+    <button onclick={fn _ => set s "Hi!"}>Click me!</button>
   </xml>}/>
 
   <active code={sleep 1; return <xml>Hi!</xml>}/>

--- a/tests/activeEmpty.py
+++ b/tests/activeEmpty.py
@@ -1,0 +1,12 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Howdy, neighbor!", alert.text)
+        alert.accept()
+        txt = self.body_text()
+        self.assertEqual("This one ain't empty.", txt)

--- a/tests/activeFocus.py
+++ b/tests/activeFocus.py
@@ -1,0 +1,18 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        uw0 = self.xpath('input[2]')
+        active = self.driver.switch_to.active_element
+        self.assertEqual(uw0, active)
+    def test_2(self):
+        """Test case 2"""
+        self.start('dynamic')
+        btn = self.xpath('button')
+        btn.click()
+        uw1 = self.xpath('span/input[2]')
+        active = self.driver.switch_to.active_element
+        self.assertEqual(uw1, active)

--- a/tests/activeFocus.ur
+++ b/tests/activeFocus.ur
@@ -14,5 +14,5 @@ fun dynamic () : transaction page =
         <ctextbox/>
         <ctextbox id={i}/>
         <active code={giveFocus i; return <xml>Done</xml>}/>
-      </xml>}/>
+      </xml>}>Click</button>
     </body></xml>

--- a/tests/agg.py
+++ b/tests/agg.py
@@ -1,0 +1,8 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('Agg/main')
+        self.assertEqual("0;1;2;\na, 50;", self.body_text())

--- a/tests/agg.ur
+++ b/tests/agg.ur
@@ -1,12 +1,22 @@
 table t1 : {A : int, B : string, C : float}
 table t2 : {A : float, D : int, E : option string}
 
-val q1 : sql_query [] _ _ = (SELECT COUNT( * ) FROM t1)
-val q2 : sql_query [] _ _ = (SELECT AVG(t1.A) FROM t1)
-val q3 : sql_query [] _ _ = (SELECT SUM(t1.C) FROM t1)
-val q4 : sql_query [] _ _ = (SELECT MIN(t1.B), MAX(t1.A) FROM t1)
-val q5 : sql_query [] _ _ = (SELECT SUM(t1.A) FROM t1 GROUP BY t1.B)
+val q1 : sql_query [] [] _ _ = (SELECT COUNT( * ) FROM t1)
+val q2 : sql_query [] [] _ _ = (SELECT AVG(t1.A) FROM t1)
+val q3 : sql_query [] [] _ _ = (SELECT SUM(t1.C) FROM t1)
+val q4 : sql_query [] [] _ _ = (SELECT MIN(t1.B), MAX(t1.A) FROM t1)
+val q5 : sql_query [] [] _ _ = (SELECT SUM(t1.A) FROM t1 GROUP BY t1.B)
 val q6 = (SELECT COUNT(t2.E) FROM t2 GROUP BY t2.D)
+
+task initialize = fn () =>
+     dml (INSERT INTO t1 (A, B, C) VALUES (1, 'a', 1.0));
+     dml (INSERT INTO t1 (A, B, C) VALUES (2, 'b', 2.0));
+     dml (INSERT INTO t1 (A, B, C) VALUES (50, 'c', 99.0));
+     dml (INSERT INTO t2 (A, D, E) VALUES (1.0, 1, NULL));
+     dml (INSERT INTO t2 (A, D, E) VALUES (1.0, 2, {[Some "a"]}));
+     dml (INSERT INTO t2 (A, D, E) VALUES (1.0, 3, NULL));
+     dml (INSERT INTO t2 (A, D, E) VALUES (1.0, 3, {[Some "b"]}));
+     dml (INSERT INTO t2 (A, D, E) VALUES (1.0, 3, {[Some "c"]}))
 
 fun main () : transaction page =
     xml <- queryX q6 (fn r => <xml>{[r.1]};</xml>);

--- a/tests/ahead.py
+++ b/tests/ahead.py
@@ -1,0 +1,15 @@
+import unittest
+import base
+import time 
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Hi!", alert.text)
+        alert.accept()
+        time.sleep(0.1)
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Bye!", alert.text)
+        alert.accept()

--- a/tests/alert.py
+++ b/tests/alert.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('a')
+        el.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("You clicked it!  That's some fancy shooting!", alert.text)

--- a/tests/alert.ur
+++ b/tests/alert.ur
@@ -1,3 +1,3 @@
 fun main () : transaction page = return <xml><body>
-    <a onclick={alert "You clicked it!  That's some fancy shooting!"}>Click Me!</a>
+    <a onclick={fn _ => alert "You clicked it!  That's some fancy shooting!"}>Click Me!</a>
   </body></xml>

--- a/tests/alert.urp
+++ b/tests/alert.urp
@@ -1,3 +1,0 @@
-debug
-
-alert

--- a/tests/align.py
+++ b/tests/align.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('p[@align="left"]')
+        self.assertEqual("Left", el.text)
+        el = self.xpath('p[@align="right"]')
+        self.assertEqual("Right", el.text)

--- a/tests/appjs.py
+++ b/tests/appjs.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('button')
+        el.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("3", alert.text)

--- a/tests/appjs.ur
+++ b/tests/appjs.ur
@@ -1,5 +1,5 @@
 fun id n = if n = 0 then 0 else 1 + id (n - 1)
 
 fun main () : transaction page = return <xml><body>
-  <button onclick={alert (show (id 3))}/>
+  <button onclick={fn _ => alert (show (id 3))}/>
 </body></xml>

--- a/tests/ascdesc.py
+++ b/tests/ascdesc.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('Ascdesc/main')
+        el = self.xpath('p[1]')
+        self.assertEqual("1; 2; 3;", el.text)
+        el = self.xpath('p[2]')
+        self.assertEqual("3; 2; 1;", el.text)

--- a/tests/ascdesc.ur
+++ b/tests/ascdesc.ur
@@ -4,7 +4,15 @@ fun sortEm b =
     queryX1 (SELECT * FROM t ORDER BY t.A {if b then sql_asc else sql_desc})
     (fn r => <xml>{[r.A]}; </xml>)
 
-fun main () : transaction page = return <xml><body>
-  <a link={sortEm True}>Ascending</a><br/>
-  <a link={sortEm False}>Descending</a>
+task initialize = fn () =>
+     dml (INSERT INTO t (A) VALUES (1));
+     dml (INSERT INTO t (A) VALUES (2));
+     dml (INSERT INTO t (A) VALUES (3))
+
+fun main () : transaction page =
+    p1 <- sortEm True;
+    p2 <- sortEm False;
+    return <xml><body>
+  <p>{p1}</p>
+  <p>{p2}</p>
 </body></xml>

--- a/tests/ascdesc.urp
+++ b/tests/ascdesc.urp
@@ -1,4 +1,3 @@
-database dbname=test
-sql ascdesc.sql
+database dbname=ascdesc
 
 ascdesc

--- a/tests/attrMangle.py
+++ b/tests/attrMangle.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('goofy[@name eq "beppo" and @data-role eq "excellence"]')
+        el.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("You clicked it!  That's some fancy shooting!", alert.text)

--- a/tests/attrs_escape.py
+++ b/tests/attrs_escape.py
@@ -1,0 +1,10 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('form/input')
+        val = el.get_attribute('value')
+        self.assertEqual("\"Well hey\"\nWow", val)

--- a/tests/attrs_escape.ur
+++ b/tests/attrs_escape.ur
@@ -1,4 +1,6 @@
-val main = fn () => <html><body>
-        <font face="\"Well hey\"
-Wow">Welcome</font>
-</body></html>
+fun main () : transaction page = return <xml><body>
+<form>
+        <submit value="\"Well hey\"
+Wow"/>
+</form>
+</body></xml>

--- a/tests/autocomp.py
+++ b/tests/autocomp.py
@@ -1,0 +1,15 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        txt = self.xpath('div')
+        self.assertEqual('/', txt.text)
+        inp = self.xpath('/input')
+        inp.send_keys('hello there')
+        self.assertEqual('hello there /', txt.text)
+        btn = self.xpath('button')
+        btn.click()
+        self.assertEqual("hello there / hello there", txt.text)

--- a/tests/autocomp.ur
+++ b/tests/autocomp.ur
@@ -2,10 +2,10 @@ fun main () : transaction page =
   a <- source "";
   b <- source "";
   return <xml><body>
-    <form>
-      <textbox{#A} source={a}/>
-      <button onclick={x <- get a; set b x}/>
+      <ctextbox source={a}/>
+      <button onclick={fn _ => x <- get a; set b x}>click me</button>
+      <div>
       <dyn signal={v <- signal a; return <xml>{[v]}</xml>}/>
       / <dyn signal={v <- signal b; return <xml>{[v]}</xml>}/>
-    </form>
+      </div>
   </body></xml>

--- a/tests/babySpawn.py
+++ b/tests/babySpawn.py
@@ -1,0 +1,12 @@
+import unittest
+import base
+import time 
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        btn = self.xpath('button')
+        btn.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual("Hi", alert.text)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,29 @@
+# use pip install selenium first
+# ensure you have both chome driver & chrome installed
+
+import unittest
+from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException
+
+class Base(unittest.TestCase):
+    """Include test cases on a given url"""
+
+    def start(self, path='main'):
+        self.driver.get('http://localhost:8080/' + path)
+    def xpath(self, path):
+        return self.driver.find_element_by_xpath('/html/body/'+path)
+    def body_text(self):
+        return self.driver.find_element_by_xpath('/html/body').text
+
+    def setUp(self):
+        """Start web driver"""
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_argument('--no-sandbox')
+        chrome_options.add_argument('--headless')
+        chrome_options.add_argument('--disable-gpu')
+        self.driver = webdriver.Chrome(options=chrome_options)
+        self.driver.implicitly_wait(10)
+
+    def tearDown(self):
+        """Stop web driver"""
+        self.driver.quit()

--- a/tests/bindpat.py
+++ b/tests/bindpat.py
@@ -1,0 +1,9 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.driver.get('http://localhost:8080/main')
+        el = self.driver.find_element_by_xpath('/html/body')
+        self.assertEqual("1, 2, hi, 2.34, 8, 9", el.text)

--- a/tests/bindpat.ur
+++ b/tests/bindpat.ur
@@ -1,6 +1,9 @@
 fun main () : transaction page =
   (a, b) <- return (1, 2);
   {C = c, ...} <- return {C = "hi", D = False};
-  d <- return 2.34;
-  {1 = e, 2 = f} <- return (8, 9);
+  let
+  val d = 2.34
+  val {1 = e, 2 = f} = (8, 9)
+  in
   return <xml>{[a]}, {[b]}, {[c]}, {[d]}, {[e]}, {[f]}</xml>
+  end

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'Supply at least one argument'
+    exit 1
+fi
+
+TESTDB=/tmp/$1.db
+TESTSQL=/tmp/$1.sql
+TESTPID=/tmp/$1.pid
+TESTSRV=./$1.exe
+
+rm -f $TESTDB $TESTSQL $TESTPID $TESTSRV
+../bin/urweb -debug -boot -noEmacs -dbms sqlite -db $TESTDB -sql $TESTSQL "$1" || exit 1
+
+if [ -e $TESTSQL ]
+then
+    sqlite3 $TESTDB < $TESTSQL
+fi
+
+$TESTSRV -q -a 127.0.0.1 &
+echo $! >> $TESTPID
+sleep 1
+python -m unittest $1.py
+kill `cat $TESTPID`

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,0 +1,14 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        p = self.xpath('p[1]')
+        self.assertEqual('Hello world! & so on, © me today (8 €)', p.text)
+        p = self.xpath('p[2]')
+        self.assertEqual('♠ ♣ ♥ ♦', p.text)
+        p = self.xpath('p[3]')
+        self.assertEqual('† DANGER †', p.text)
+

--- a/tests/entities.ur
+++ b/tests/entities.ur
@@ -1,5 +1,5 @@
 fun main () : transaction page = return <xml><body>
-  Hello world! &amp; so on, &copy; me today (8 &euro;)<br/>
-  &spades; &clubs; &hearts; &diams;<br/>
-  &dagger; DANGER &dagger;
+  <p>Hello world! &amp; so on, &copy; me today (8 &euro;)</p>
+  <p>&spades; &clubs; &hearts; &diams;</p>
+  <p>&dagger; DANGER &dagger;</p>
 </body></xml>

--- a/tests/fact.py
+++ b/tests/fact.py
@@ -1,0 +1,10 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        b = self.driver.find_element_by_xpath('/html/body')
+        self.assertEqual('3628800, 3628800', b.text)
+

--- a/tests/filter.py
+++ b/tests/filter.py
@@ -1,0 +1,9 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start('Filter/main')
+        tx = self.body_text()
+        self.assertEqual("4, 4; 44, 4.4;", tx)

--- a/tests/filter.ur
+++ b/tests/filter.ur
@@ -1,9 +1,16 @@
-fun filter [fs ::: {Type}] [ks] (t : sql_table fs ks) (p : sql_exp [T = fs] [] [] bool)
-   : sql_query [T = fs] [] =
+fun filter [fs ::: {Type}] [ks] (t : sql_table fs ks) (p : sql_exp [T = fs] [] [] bool) =
    (SELECT * FROM t WHERE {p})
 
 table t : { A : int, B : float }
 
-fun main () =
-    queryX (filter t (WHERE t.A > 3))
-           (fn r => <xml>{[r.T.A]}, {[r.T.B]}</xml>)
+task initialize = fn () =>
+     dml (INSERT INTO t (A, B) VALUES (1, 2.0));
+     dml (INSERT INTO t (A, B) VALUES (2, 1.0));
+     dml (INSERT INTO t (A, B) VALUES (3, 3.0));
+     dml (INSERT INTO t (A, B) VALUES (4, 4.0));
+     dml (INSERT INTO t (A, B) VALUES (44, 4.4))
+
+fun main () : transaction page =
+    r <- queryX (filter t (WHERE t.A > 3))
+                (fn r => <xml>{[r.T.A]}, {[r.T.B]}; </xml>);
+    return <xml><body>{r}</body></xml>

--- a/tests/jsbspace.py
+++ b/tests/jsbspace.py
@@ -1,0 +1,11 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+        el = self.xpath('button')
+        el.click()
+        alert = self.driver.switch_to.alert
+        self.assertEqual('Some \btext', alert.text)

--- a/tests/jsbspace.ur
+++ b/tests/jsbspace.ur
@@ -1,0 +1,12 @@
+fun main () : transaction page =
+let
+  fun onclick (): transaction unit =
+    (* this function runs on the client *)
+    alert "Some \btext"
+in
+return <xml>
+  <body>
+    <button onclick={fn _ => onclick()}>Click me!</button>
+  </body>
+</xml>
+end

--- a/tests/jsonTest.py
+++ b/tests/jsonTest.py
@@ -1,0 +1,16 @@
+import unittest
+import base
+
+class Suite(base.Base):
+    def test_1(self):
+        """Test case 1"""
+        self.start()
+
+        pre = self.xpath('pre[1]')
+        self.assertEqual('line 1\nline 2', pre.text)
+
+        pre = self.xpath('pre[2]')
+        self.assertEqual('1 :: 2 :: 3 :: []', pre.text)
+
+        pre = self.xpath('pre[3]')
+        self.assertEqual('["hi","bye\\"","hehe"]', pre.text)

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -2,6 +2,6 @@ open Json
 
 fun main () : transaction page = return <xml><body>
   <pre>{[ fromJson "\"line 1\\nline 2\"" : string ]}</pre><br/>
-  {[fromJson "[1, 2, 3]" : list int]}<br/>
-  {[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}
+  <pre>{[fromJson "[1, 2, 3]" : list int]}</pre><br/>
+  <pre>{[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}</pre>
 </body></xml>


### PR DESCRIPTION
This PR adds [WebDriver](https://www.w3.org/TR/webdriver/) scripting using [Python and Selenium](https://www.seleniumhq.org/projects/webdriver/).

To use, install Chrome & Chrome WebDriver, then:

````bash
$ cd tests
$ make simple
````
This will, per each test-case listed:

* compile the Ur/Web source code into an executable webserver and run it
* run test suite that is located in the corresponding `.py` file

The Python test suite code will drive a headless Chrome browser to perform actions that a user would typically perform.

This still needs improvements:

* the top-level test-runner is very dumb (will simply run tests one by one, slowly)
* many more existing test cases need to be included
* run all these tests in Travis-CI

I'd like to get feedback on this!