### PR TITLE
Improved support for JSON escape characters

### DIFF
--- a/lib/ur/json.ur
+++ b/lib/ur/json.ur
@@ -52,6 +52,7 @@ fun escape s =
 		       | #"\t" => "\\t"
 		       | #"\"" => "\\\""
 		       | #"\'" => "\\\'"
+		       | #"\\" => "\\\\"
 		       | x => String.str ch
 		    ) ^ esc (String.suffix s 1)
                 end
@@ -100,6 +101,7 @@ fun unescape s =
                                | #"t" => "\t"
                                | #"\"" => "\""
                                | #"\'" => "\'"
+			       | #"\\" => "\\"
                                | x => error <xml>JSON unescape: Bad escape char: {[x]}</xml>)
 			    ^
 			    unesc (i+2)

--- a/lib/ur/json.ur
+++ b/lib/ur/json.ur
@@ -53,6 +53,7 @@ fun escape s =
 		       | #"\"" => "\\\""
 		       | #"\'" => "\\\'"
 		       | #"\\" => "\\\\"
+		       | #"/" => "\\/"
 		       | x => String.str ch
 		    ) ^ esc (String.suffix s 1)
                 end
@@ -102,6 +103,7 @@ fun unescape s =
                                | #"\"" => "\""
                                | #"\'" => "\'"
 			       | #"\\" => "\\"
+			       | #"/" => "/"
                                | x => error <xml>JSON unescape: Bad escape char: {[x]}</xml>)
 			    ^
 			    unesc (i+2)

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -2,6 +2,6 @@ open Json
 
 fun main () : transaction page = return <xml><body>
   <pre>{[ fromJson "\"\\\\line \/ 1\\nline 2\"" : string ]}</pre><br/>
-  {[fromJson "[1, 2, 3]" : list int]}<br/>
-  {[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}
+  <pre>{[fromJson "[1, 2, 3]" : list int]}</pre><br/>
+  <pre>{[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}</pre>
 </body></xml>

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -1,7 +1,7 @@
 open Json
 
 fun main () : transaction page = return <xml><body>
-  <pre>{[ fromJson "\"line 1\\nline 2\"" : string ]}</pre><br/>
+  <pre>{[ fromJson "\"\\\\line 1\\nline 2\"" : string ]}</pre><br/>
   {[fromJson "[1, 2, 3]" : list int]}<br/>
   {[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}
 </body></xml>

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -1,7 +1,7 @@
 open Json
 
 fun main () : transaction page = return <xml><body>
-  <pre>{[ fromJson "\"\\\\line 1\\nline 2\"" : string ]}</pre><br/>
+  <pre>{[ fromJson "\"\\\\line \/ 1\\nline 2\"" : string ]}</pre><br/>
   {[fromJson "[1, 2, 3]" : list int]}<br/>
   {[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}
 </body></xml>


### PR DESCRIPTION
Support was added for escaping '\' '/' ommited                                                                                                                                                                     
in 2bc51bd866b52bc738f259ffe6e9fb8f6068a6b6                                                                                                                                                                        
These are specified in https://www.json.org

