### PR TITLE
Same page link anchors

### DIFF
--- a/include/urweb/urweb_cpp.h
+++ b/include/urweb/urweb_cpp.h
@@ -242,6 +242,7 @@ uw_Basis_string uw_Basis_blessEnvVar(struct uw_context *, uw_Basis_string);
 uw_Basis_string uw_Basis_blessMeta(struct uw_context *, uw_Basis_string);
 
 uw_Basis_string uw_Basis_checkUrl(struct uw_context *, uw_Basis_string);
+uw_Basis_string uw_Basis_anchorUrl(struct uw_context *, uw_Basis_string);
 uw_Basis_string uw_Basis_checkMime(struct uw_context *, uw_Basis_string);
 uw_Basis_string uw_Basis_checkRequestHeader(struct uw_context *, uw_Basis_string);
 uw_Basis_string uw_Basis_checkResponseHeader(struct uw_context *, uw_Basis_string);

--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -2278,5 +2278,9 @@ function giveFocus(id) {
         er("Tried to give focus to ID not used in document: " + id);
 }
 
+function anchorUrl(id) {
+    return "#" + id;
+}
+
 
 // App-specific code

--- a/lib/ur/basis.urs
+++ b/lib/ur/basis.urs
@@ -803,6 +803,7 @@ type id
 val fresh : transaction id
 val giveFocus : id -> transaction unit
 val show_id : show id
+val anchorUrl : id -> url
 
 val dyn : ctx ::: {Unit} -> use ::: {Type} -> bind ::: {Type} -> [ctx ~ [Dyn]] => unit
           -> tag [Signal = signal (xml ([Dyn] ++ ctx) use bind)] ([Dyn] ++ ctx) [] use bind

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -4407,6 +4407,10 @@ uw_Basis_string uw_Basis_currentUrl(uw_context ctx) {
   return ctx->current_url;
 }
 
+uw_Basis_string uw_Basis_anchorUrl(uw_context ctx, uw_Basis_string s) {
+  return uw_Basis_strcat(ctx, uw_Basis_strcat(ctx, ctx->current_url, "#"), s);
+}
+
 void uw_set_currentUrl(uw_context ctx, char *s) {
   ctx->current_url = s;
 }

--- a/src/settings.sml
+++ b/src/settings.sml
@@ -321,6 +321,7 @@ val jsFuncsBase = basisM [("alert", "alert"),
                           ("ord", "ord"),
 
                           ("checkUrl", "checkUrl"),
+                          ("anchorUrl", "anchorUrl"),
                           ("bless", "bless"),
                           ("blessData", "blessData"),
 


### PR DESCRIPTION
Here's a implementation of anchor links enabling the user to link to the middle of the page in a safe fashion. With this branch I was able to compile the page I've been fiddling with. It's a bit rough because it reuses the `id`'s to create new anchors, so they look like `#uw0` etc rather than something nice like `#contact-me`.

If you would welcome this addition to urweb, I can separate it from `id`s to allow nice named anchors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/urweb/urweb/136)
<!-- Reviewable:end -->
