### PR TITLE
Use our own memmem only when libc doesn’t have one

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,8 @@ pthread_t a;
     AC_MSG_RESULT(yes),
   AC_MSG_RESULT(no))
 
+AC_CHECK_FUNCS_ONCE([memmem])
+
 AC_SUBST(CC)
 AC_SUBST(BIN)
 AC_SUBST(LIB)

--- a/src/c/memmem.c
+++ b/src/c/memmem.c
@@ -1,4 +1,6 @@
-#include "config.h"
+#include "memmem.h"
+
+#ifndef HAVE_MEMMEM
 
 /* $NetBSD$ */
  
@@ -38,8 +40,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Function renamed by Adam Chlipala in 2016.
-
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)
 __RCSID("$NetBSD$");
@@ -54,13 +54,8 @@ __RCSID("$NetBSD$");
 #define NULL            ((char *)0)
 #endif
 
-/*
- * urweb_memmem() returns the location of the first occurence of data
- * pattern b2 of size len2 in memory block b1 of size len1 or
- * NULL if none is found.
- */
 void *
-urweb_memmem(const void *b1, size_t len1, const void *b2, size_t len2)
+memmem(const void *b1, size_t len1, const void *b2, size_t len2)
 {
         /* Sanity check */
         if(!(b1 != NULL && b2 != NULL && len1 != 0 && len2 != 0))
@@ -85,3 +80,5 @@ urweb_memmem(const void *b1, size_t len1, const void *b2, size_t len2)
 
         return NULL;
 }
+
+#endif  // !defined(HAVE_MEMMEM)

--- a/src/c/memmem.h
+++ b/src/c/memmem.h
@@ -1,0 +1,23 @@
+#ifndef URWEB_MEMMEM_H
+#define URWEB_MEMMEM_H
+
+#include "config.h"
+
+#ifdef HAVE_MEMMEM
+
+#include <string.h>
+
+#else  // !defined(HAVE_MEMMEM)
+
+#include <stddef.h>
+
+/*
+ * memmem() returns the location of the first occurence of data
+ * pattern b2 of size len2 in memory block b1 of size len1 or
+ * NULL if none is found.
+ */
+void *memmem(const void *b1, size_t len1, const void *b2, size_t len2);
+
+#endif  // !defined(HAVE_MEMMEM)
+
+#endif  // URWEB_MEMMEM_H

--- a/src/c/request.c
+++ b/src/c/request.c
@@ -11,12 +11,11 @@
 
 #include <pthread.h>
 
+#include "memmem.h"
 #include "urweb.h"
 #include "request.h"
 
 #define MAX_RETRIES 5
-
-void *urweb_memmem(const void *b1, size_t len1, const void *b2, size_t len2);
 
 static int try_rollback(uw_context ctx, int will_retry, void *logger_data, uw_logger log_error) {
   int r = uw_rollback(ctx, will_retry);
@@ -422,7 +421,7 @@ request_result uw_request(uw_request_context rc, uw_context ctx,
         }
       }
 
-      part = urweb_memmem(after_sub_headers, body + body_len - after_sub_headers, boundary, boundary_len);
+      part = memmem(after_sub_headers, body + body_len - after_sub_headers, boundary, boundary_len);
       if (!part) {
         log_error(logger_data, "Missing boundary after multipart payload\n");
         return FAILED;


### PR DESCRIPTION
Systems without `memmem` are getting rarer every day. (I think only MinGW and some very exotic platforms lack it at this point.) We can improve efficiency by relying on libc’s `memmem` whenever possible.

This commit changes the `configure` process to detect whether `memmem` is defined in string.h. If it
does, memmem.h will preprocess as `#include <string.h>`, and memmem.c will become an empty file. If it doesn’t, memmem.h and memmem.c remain basically unchanged, with the exception that I’ve undone the renaming from 6dad7c645d8fdb7b7237c89ff7b34e90adbb86b1. (Since we’re only creating a memmem prototype if libc doesn’t define the symbol, our prototype should never clash with libc’s.)