### PR TITLE
Replace timelocal usage with mktime

### DIFF
--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -4238,7 +4238,7 @@ uw_Basis_time uw_Basis_fromDatetime(uw_context ctx, uw_Basis_int year, uw_Basis_
   struct tm tm = { .tm_year = year - 1900, .tm_mon = month, .tm_mday = day,
                    .tm_hour = hour, .tm_min = minute, .tm_sec = second,
                    .tm_isdst = -1 };
-  uw_Basis_time r = { timelocal(&tm) };
+  uw_Basis_time r = { mktime(&tm) };
   return r;
 }
 


### PR DESCRIPTION
timelocal is a non-standard GNU extension and equivalent
to the POSIX standard mktime. musl-libc doesn't have
timelocal, preventing fully static builds of urweb with
musl.