### PR TITLE
Try to use UTF-8 rather than numeric HTML escapes

### DIFF
--- a/src/c/Makefile.am
+++ b/src/c/Makefile.am
@@ -11,7 +11,7 @@ AM_CFLAGS = -Wall -Wunused-parameter -Werror -Wno-format-security -Wno-deprecate
 liburweb_la_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS) \
 	-export-symbols-regex '^(client_pruner|pthread_create_big|strcmp_nullsafe|uw_.*)' \
 	-version-info 1:0:0
-liburweb_la_LIBADD = $(PTHREAD_LIBS) -lm $(OPENSSL_LIBS) $(ICU_LIBS) -licui18n -licuuc -licudata
+liburweb_la_LIBADD = $(PTHREAD_LIBS) -lm $(OPENSSL_LIBS) $(ICU_LIBS) -licui18n -licuuc -licudata -licuio
 liburweb_http_la_LIBADD = liburweb.la
 liburweb_http_la_LDFLAGS = -export-symbols-regex '^(main|uw_.*)' \
 	-version-info 1:0:0

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -2351,14 +2351,10 @@ uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
 
   if(uw_Basis_isprint(ctx, ch)) {
 
-    const UChar ins[1] = { ch };
-    char buf[5];
     int32_t len_written = 0;
     UErrorCode err = U_ZERO_ERROR;
 
-    u_strToUTF8(buf, 5, &len_written, ins, 1, &err);
-    sprintf(ctx->page.front, "%s", buf);
-    // printf("buf: %s, hex: %x, len_written: %d, err: %s\n", buf, ch, len_written, u_errorName(err));
+    u_strToUTF8(ctx->page.front, 5, &len_written, (const UChar*)&ch, 1, &err);
     len = len_written;
   }
 

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -20,6 +20,7 @@
 
 #include <pthread.h>
 
+#include <unicode/utf8.h>
 #include <unicode/ustring.h>
 #include <unicode/uchar.h>
 
@@ -2344,7 +2345,7 @@ char *uw_Basis_htmlifySpecialChar(uw_context ctx, uw_Basis_char ch) {
 
 uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
   unsigned int n = ch;
-  int len;
+  int len = 0;
 
   uw_check(ctx, INTS_MAX+3);
 
@@ -2359,7 +2360,10 @@ uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
     sprintf(ctx->page.front, "%s", buf);
     // printf("buf: %s, hex: %x, len_written: %d, err: %s\n", buf, ch, len_written, u_errorName(err));
     len = len_written;
-  } else {
+  }
+
+  // either it's a non-printable character, or we failed to convert to UTF-8
+  if(len == 0) {
     len = sprintf(ctx->page.front, "&#%u;", n);
   }
   ctx->page.front += len;

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -21,6 +21,7 @@
 #include <pthread.h>
 
 #include <unicode/uchar.h>
+#include <unicode/ustring.h>
 
 #include "types.h"
 

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -20,7 +20,6 @@
 
 #include <pthread.h>
 
-#include <unicode/utf8.h>
 #include <unicode/uchar.h>
 
 #include "types.h"
@@ -2347,7 +2346,21 @@ uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
   int len;
 
   uw_check(ctx, INTS_MAX+3);
-  len = sprintf(ctx->page.front, "&#%u;", n);
+
+  if(uw_Basis_isprint(ctx, ch)) {
+
+    UChar32 ins[1] = { ch };
+    char buf[5];
+    int32_t len_written = 0;
+    UErrorCode err = U_ZERO_ERROR;
+
+    u_strToUTF8(buf, 5, &len_written, ins, 1, &err);
+    sprintf(ctx->page.front, "%s", buf);
+    // printf("buf: %s, hex: %x, len_written: %d, err: %s\n", buf, ch, len_written, u_errorName(err));
+    len = len_written;
+  } else {
+    len = sprintf(ctx->page.front, "&#%u;", n);
+  }
   ctx->page.front += len;
 
   return uw_unit_v;
@@ -2459,7 +2472,7 @@ uw_unit uw_Basis_htmlifyString_w(uw_context ctx, uw_Basis_string s) {
     else {
       uw_Basis_htmlifySpecialChar_w(ctx, c1);
     }    
-  }  
+  }
 
   return uw_unit_v;
 }

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -20,8 +20,8 @@
 
 #include <pthread.h>
 
-#include <unicode/uchar.h>
 #include <unicode/ustring.h>
+#include <unicode/uchar.h>
 
 #include "types.h"
 
@@ -2350,7 +2350,7 @@ uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
 
   if(uw_Basis_isprint(ctx, ch)) {
 
-    UChar32 ins[1] = { ch };
+    const UChar ins[1] = { ch };
     char buf[5];
     int32_t len_written = 0;
     UErrorCode err = U_ZERO_ERROR;

--- a/src/compiler.sml
+++ b/src/compiler.sml
@@ -1610,9 +1610,13 @@ fun compileC {cname, oname, ename, libs, profile, debug, linker, link = link'} =
         val proto = Settings.currentProtocol ()
 
         val lib = if Settings.getBootLinking () then
-                      !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^ !Settings.configLib ^ "/liburweb.a " ^ !Settings.configIcuLibs ^ " -licui18n -licuuc -licudata"
+                      !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^
+                      !Settings.configLib ^ "/liburweb.a " ^
+                      !Settings.configIcuLibs ^ " -licui18n -licuuc -licudata -licuio"
                   else if Settings.getStaticLinking () then
-                      " -static " ^ !Settings.configLib ^ "/" ^ #linkStatic proto ^ " " ^ !Settings.configLib ^ "/liburweb.a " ^ !Settings.configIcuLibs ^ " -licui18n -licuuc -licudata"
+                      " -static " ^ !Settings.configLib ^ "/" ^ #linkStatic
+                      proto ^ " " ^ !Settings.configLib ^ "/liburweb.a " ^
+                      !Settings.configIcuLibs ^ " -licui18n -licuuc -licudata -licuio"
                   else
                       "-L" ^ !Settings.configLib ^ " " ^ #linkDynamic proto ^ " -lurweb"
 


### PR DESCRIPTION
I noticed that Ur/Web (starting from commit 5cc729b48aad084757a049b7e5cdbadae5e9e400) fails the "Fortunes" test in the Techempower framework benchmarks. The failure is due to the fact that we convert non-ASCII characters to HTML numeric escape sequences, when it seems standard to just output UTF-8 nowadays.

This PR makes the following changes:
* When htmlifying characters, don't use numeric escapes if they're printable -- instead, try to convert them to UTF-8.
* Add libicuio to linked C libraries

Note that this was done without significant understanding of how Ur/Web works, and my testing has been limited to running the different benchmark problems and a couple of toy programs. It's possible that this change might have negative side-effects I don't know about. Any input here would be appreciated.