### PR TITLE
Remove sscanf from blob processing

### DIFF
--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -3421,10 +3421,19 @@ uw_Basis_blob uw_Basis_stringToBlob_error(uw_context ctx, uw_Basis_string s, siz
     s += 2;
 
     while (*s) {
+      char a = s[0];
+      s += 1;
+      char b;
+      if (*s){
+        b = s[0];
+      } else {
+        b = 0;
+      }
       int n;
-      sscanf(s, "%02x", &n);
+      char buf[3] = {a, b, 0};
+      n = strtol(buf, NULL, 16);
       *r++ = n;
-      s += 2;
+      s += 1;
     }
   } else {
     while (*s) {


### PR DESCRIPTION
Saving relatively big files (1MB+) has always been very slow for me (see also #171). I looked into this and it's indeed a known problem that sscanf is slow for really long strings. People were recommending to use strtol instead. I've tried this solution and it works, it's WAY faster (going from 30s to process a 5MB file to mere milliseconds), but my C skills are pretty much non-existent, so a review from someone who actually knows what he/she's doing would be much appreciated!