### PR TITLE
Remove Name, Type, and Unit keywords

### DIFF
--- a/demo/crud.ur
+++ b/demo/crud.ur
@@ -1,5 +1,5 @@
 con colMeta = fn (db :: Type, widget :: Type) =>
-                 {Nam : string,
+                 {Name : string,
                   Show : db -> xbody,
                   Widget : nm :: Name -> xml form [] [nm = widget],
                   WidgetPopulated : nm :: Name -> db -> xml form [] [nm = widget],
@@ -9,7 +9,7 @@ con colsMeta = fn cols => $(map colMeta cols)
 
 fun default [t] (sh : show t) (rd : read t) (inj : sql_injectable t)
             name : colMeta (t, string) =
-    {Nam = name,
+    {Name = name,
      Show = txt,
      Widget = fn [nm :: Name] => <xml><textbox{nm}/></xml>,
      WidgetPopulated = fn [nm :: Name] n =>
@@ -21,7 +21,7 @@ val int = default
 val float = default
 val string = default
 
-fun bool name = {Nam = name,
+fun bool name = {Name = name,
                  Show = txt,
                  Widget = fn [nm :: Name] => <xml><checkbox{nm}/></xml>,
                  WidgetPopulated = fn [nm :: Name] b =>
@@ -67,7 +67,7 @@ functor Make(M : sig
               <th>ID</th>
               {@mapX [colMeta] [tr]
                 (fn [nm :: Name] [t ::_] [rest ::_] [[nm] ~ rest] col => <xml>
-                  <th>{cdata col.Nam}</th>
+                  <th>{cdata col.Name}</th>
                 </xml>)
                 M.fl M.cols}
             </tr>
@@ -79,7 +79,7 @@ functor Make(M : sig
           <form>
             {@foldR [colMeta] [fn cols => xml form [] (map snd cols)]
               (fn [nm :: Name] [t ::_] [rest ::_] [[nm] ~ rest] (col : colMeta t) acc => <xml>
-                <li> {cdata col.Nam}: {col.Widget [nm]}</li>
+                <li> {cdata col.Name}: {col.Widget [nm]}</li>
                 {useMore acc}
               </xml>)
               <xml/>
@@ -131,7 +131,7 @@ functor Make(M : sig
                   (fn [nm :: Name] [t ::_] [rest ::_] [[nm] ~ rest] v (col : colMeta t)
                                    (acc : xml form [] (map snd rest)) =>
                       <xml>
-                        <li> {cdata col.Nam}: {col.WidgetPopulated [nm] v}</li>
+                        <li> {cdata col.Name}: {col.WidgetPopulated [nm] v}</li>
                         {useMore acc}
                       </xml>)
                   <xml/>

--- a/demo/crud.urs
+++ b/demo/crud.urs
@@ -1,5 +1,5 @@
 con colMeta = fn (db :: Type, widget :: Type) =>
-                 {Nam : string,
+                 {Name : string,
                   Show : db -> xbody,
                   Widget : nm :: Name -> xml form [] [nm = widget],
                   WidgetPopulated : nm :: Name -> db -> xml form [] [nm = widget],

--- a/src/elaborate.sml
+++ b/src/elaborate.sml
@@ -310,9 +310,11 @@
        | L.KWild => if !inSignature then (kindError env (KDisallowedWildcard loc); kerror) else kunif env loc
 
        | L.KVar s => (case E.lookupK env s of
-                          NONE =>
-                          (kindError env (UnboundKind (loc, s));
-                           kerror)
+                          NONE => (case s of
+                                       "Name" => (L'.KName, loc)
+                                     | "Type" => (L'.KType, loc)
+                                     | "Unit" => (L'.KUnit, loc)
+                                     | _ => (kindError env (UnboundKind (loc, s)); kerror))
                         | SOME n => (L'.KRel n, loc))
        | L.KFun (x, k) => (L'.KFun (x, elabKind (E.pushKRel env x) k), loc)
 

--- a/src/urweb.grm
+++ b/src/urweb.grm
@@ -376,9 +376,8 @@ fun patternOut (e : exp) =
  | LPAREN | RPAREN | LBRACK | RBRACK | LBRACE | RBRACE
  | EQ | COMMA | COLON | DCOLON | DCOLONWILD | TCOLON | TCOLONWILD | DOT | HASH | UNDER | UNDERUNDER | BAR
  | PLUS | MINUS | DIVIDE | DOTDOTDOT | MOD | AT
- | CON | LTYPE | VAL | REC | AND | FUN | MAP | UNIT | KUNIT | CLASS | FFI
+ | CON | LTYPE | VAL | REC | AND | FUN | MAP | UNIT | CLASS | FFI
  | DATATYPE | OF
- | TYPE | NAME
  | ARROW | LARROW | DARROW | STAR | SEMI | KARROW | DKARROW | BANG
  | FN | PLUSPLUS | MINUSMINUS | MINUSMINUSMINUS | DOLLAR | TWIDDLE | CARET
  | LET | IN
@@ -1025,12 +1024,9 @@ str    : STRUCT decls END               (StrConst decls, s (STRUCTleft, ENDright
 spath  : CSYMBOL                        (StrVar CSYMBOL, s (CSYMBOLleft, CSYMBOLright))
        | spath DOT CSYMBOL              (StrProj (spath, CSYMBOL), s (spathleft, CSYMBOLright))
 
-kind   : TYPE                           (KType, s (TYPEleft, TYPEright))
-       | NAME                           (KName, s (NAMEleft, NAMEright))
-       | LBRACE kind RBRACE             (KRecord kind, s (LBRACEleft, RBRACEright))
+kind   : LBRACE kind RBRACE             (KRecord kind, s (LBRACEleft, RBRACEright))
        | kind ARROW kind                (KArrow (kind1, kind2), s (kind1left, kind2right))
        | LPAREN kind RPAREN             (#1 kind, s (LPARENleft, RPARENright))
-       | KUNIT                          (KUnit, s (KUNITleft, KUNITright))
        | UNDERUNDER                     (KWild, s (UNDERUNDERleft, UNDERUNDERright))
        | LPAREN ktuple RPAREN           (KTuple ktuple, s (LPARENleft, RPARENright))
        | CSYMBOL                        (KVar CSYMBOL, s (CSYMBOLleft, CSYMBOLright))

--- a/src/urweb.lex
+++ b/src/urweb.lex
@@ -459,10 +459,6 @@ xint = x[0-9a-fA-F][0-9a-fA-F];
 <INITIAL> "policy"    => (Tokens.POLICY (pos yypos, pos yypos + size yytext));
 <INITIAL> "ffi"       => (Tokens.FFI (pos yypos, pos yypos + size yytext));
 
-<INITIAL> "Type"      => (Tokens.TYPE (pos yypos, pos yypos + size yytext));
-<INITIAL> "Name"      => (Tokens.NAME (pos yypos, pos yypos + size yytext));
-<INITIAL> "Unit"      => (Tokens.KUNIT (pos yypos, pos yypos + size yytext));
-
 <INITIAL> "SELECT"    => (Tokens.SELECT (pos yypos, pos yypos + size yytext));
 <INITIAL> "DISTINCT"  => (Tokens.DISTINCT (pos yypos, pos yypos + size yytext));
 <INITIAL> "FROM"      => (Tokens.FROM (pos yypos, pos yypos + size yytext));


### PR DESCRIPTION
This allows them to be used as the names for record fields and SQL
table columns.

Commit updates demo/crud to demonstrate using Name instead of Nam.

Fixes #204.