### PR TITLE
Fix a handful of Unicode issues

### DIFF
--- a/lib/ur/basis.urs
+++ b/lib/ur/basis.urs
@@ -95,7 +95,6 @@ val strsindex : string -> string -> option int
 val strcspn : string -> string -> int
 val substring : string -> int -> int -> string
 val str1 : char -> string
-val ofUnicode : int -> string
 
 class show
 val show : t ::: Type -> show t -> t -> string

--- a/lib/ur/top.ur
+++ b/lib/ur/top.ur
@@ -449,3 +449,5 @@ fun min [t] ( _ : ord t) (x : t) (y : t) : t =
 
 fun assert [a] (cond: bool) (msg: string) (loc: string) (x:a): a =
   if cond then x else error <xml>{txt msg} at {txt loc}</xml>
+
+val ofUnicode = compose str1 chr

--- a/lib/ur/top.urs
+++ b/lib/ur/top.urs
@@ -317,3 +317,5 @@ val assert : t ::: Type
              -> string (* Source location of the bad thing *)
              -> t      (* Return this value if all went well. *)
              -> t
+
+val ofUnicode : int -> string

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -21,7 +21,6 @@
 #include <pthread.h>
 
 #include <unicode/utf8.h>
-#include <unicode/ustring.h>
 #include <unicode/uchar.h>
 
 #include "types.h"

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -4624,7 +4624,7 @@ uw_Basis_int uw_Basis_ord(uw_context ctx, uw_Basis_char c) {
 
 uw_Basis_bool uw_Basis_iscodepoint(uw_context ctx, uw_Basis_int n) {
   (void)ctx;
-  return !!(n <= 0x10FFFF);
+  return !!(0 <= n && n <= 0x10FFFF);
 }
 
 uw_Basis_bool uw_Basis_issingle(uw_context ctx, uw_Basis_char c) {
@@ -4633,14 +4633,10 @@ uw_Basis_bool uw_Basis_issingle(uw_context ctx, uw_Basis_char c) {
 }
 
 uw_Basis_char uw_Basis_chr(uw_context ctx, uw_Basis_int n) {
-  (void)ctx;
-  uw_Basis_char ch = (uw_Basis_char)n;
-
-  if (n < 0 || n > 0x10FFFF) {
+  if (!uw_Basis_iscodepoint(ctx, n)) {
     uw_error(ctx, FATAL, "The integer %lld is not a valid char codepoint", n);
   }
-
-  return ch;
+  return (uw_Basis_char)n;
 }
 
 uw_Basis_string uw_Basis_currentUrl(uw_context ctx) {

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -2374,12 +2374,7 @@ uw_unit uw_Basis_htmlifySpecialChar_w(uw_context ctx, uw_Basis_char ch) {
   uw_check(ctx, INTS_MAX+3);
 
   if(uw_Basis_isprint(ctx, ch)) {
-
-    int32_t len_written = 0;
-    UErrorCode err = U_ZERO_ERROR;
-
-    u_strToUTF8(ctx->page.front, 5, &len_written, (const UChar*)&ch, 1, &err);
-    len = len_written;
+    U8_APPEND_UNSAFE(ctx->page.front, len, ch);
   }
 
   // either it's a non-printable character, or we failed to convert to UTF-8
@@ -2746,18 +2741,6 @@ uw_Basis_string uw_Basis_str1(uw_context ctx, uw_Basis_char ch) {
 
   ctx->heap.front += req + 1;
   return r; 
-}
-
-uw_Basis_string uw_Basis_ofUnicode(uw_context ctx, uw_Basis_int n) {
-  UChar buf16[] = {n};
-  uw_Basis_string out = uw_malloc(ctx, 3);
-  int32_t outLen;
-  UErrorCode pErrorCode = 0;
-
-  if (u_strToUTF8(out, 3, &outLen, buf16, 1, &pErrorCode) == NULL || outLen == 0)
-    uw_error(ctx, FATAL, "Bad Unicode string to unescape (error %s)", u_errorName(pErrorCode));
-
-  return out;
 }
 
 uw_Basis_string uw_strdup(uw_context ctx, uw_Basis_string s1) {
@@ -4654,7 +4637,7 @@ uw_Basis_char uw_Basis_chr(uw_context ctx, uw_Basis_int n) {
   (void)ctx;
   uw_Basis_char ch = (uw_Basis_char)n;
 
-  if (n > 0x10FFFF) {
+  if (n < 0 || n > 0x10FFFF) {
     uw_error(ctx, FATAL, "The integer %lld is not a valid char codepoint", n);
   }
 

--- a/tests/issue207.ur
+++ b/tests/issue207.ur
@@ -1,0 +1,8 @@
+val s1 = "𝕬" (* U+1D56C *)
+val s2 : string = Json.fromJson "\"\\uD55C\\uD55C\\uD55C\\uD55C\""
+
+val main x : transaction page =
+    return <xml><body>
+      <p>{[s1]} {[if x then s1 else s1]}</p>
+      <p>{[s2]}</p>
+    </body></xml>

--- a/tests/issue207.urp
+++ b/tests/issue207.urp
@@ -1,0 +1,6 @@
+rewrite url Issue207/main
+
+$/char
+$/string
+$/json
+issue207


### PR DESCRIPTION
uw_Basis_htmlifySpecialChar_w was using s_strToUTF8, which only
supports UTF-16. To support extended plane characters, this commit
changes it to use U8_APPEND_UNSAFE, like the rest of the basis
implementation.

uw_Basis_ofUnicode was similarly doing the wrong thing, using
s_strToUTF8 and even corrupting memory by failing to reserve enough
storage space. Rather than fixing its C code, this commit moves it
from Basis to Top, and reimplements it in terms of Basis.chr and
Basis.str1.

Finally, this commit tightens Basis.chr to reject negative integers.

Fixes #207.