### PR TITLE
Drop legacy OpenSSL support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,22 +109,6 @@ if test [$WORKING_VERSION = "1"]; then
    VERSION="$VERSION + `git log -1 --format="%H" || echo ?`"
 fi
 
-# Check if pthread_t is a scalar or pointer type so we can use the correct
-# OpenSSL functions on it.
-AC_MSG_CHECKING([if pthread_t is a pointer type])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-     [[
-#include <pthread.h>
-     ]],
-     [[
-pthread_t a;
-*a;
-     ]])],
-  AC_DEFINE([PTHREAD_T_IS_POINTER], [1], [Define if pthread_t is a pointer.])
-    AC_MSG_RESULT(yes),
-  AC_MSG_RESULT(no))
-
 AC_CHECK_FUNCS_ONCE([memmem])
 
 AC_SUBST(CC)

--- a/src/c/openssl.c
+++ b/src/c/openssl.c
@@ -8,9 +8,14 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 #include <openssl/sha.h>
 #include <openssl/rand.h>
+
+#if !defined(OPENSSL_THREADS)
+#error "Ur/Web requires OpenSSL configured with thread support"
+#endif
 
 #define PASSSIZE 4
 
@@ -28,70 +33,7 @@ static void random_password() {
   }
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-// We're using OpenSSL <1.1, so we need to specify threading callbacks.  See
-// threads(3SSL).
-
-#include <assert.h>
-#include <pthread.h>
-
-#include <openssl/crypto.h>
-
-static pthread_mutex_t *openssl_locks;
-
-// OpenSSL callbacks
-#ifdef PTHREAD_T_IS_POINTER
-static void thread_id(CRYPTO_THREADID *const result) {
-  CRYPTO_THREADID_set_pointer(result, pthread_self());
-}
-#else
-static void thread_id(CRYPTO_THREADID *const result) {
-  CRYPTO_THREADID_set_numeric(result, (unsigned long)pthread_self());
-}
-#endif
-
-static void lock_or_unlock(const int mode, const int type, const char *file,
-                           const int line) {
-  pthread_mutex_t *const lock = &openssl_locks[type];
-  if (mode & CRYPTO_LOCK) {
-    if (pthread_mutex_lock(lock)) {
-      fprintf(stderr, "Can't take lock at %s:%d\n", file, line);
-      exit(1);
-    }
-  } else {
-    if (pthread_mutex_unlock(lock)) {
-      fprintf(stderr, "Can't release lock at %s:%d\n", file, line);
-      exit(1);
-    }
-  }
-}
-
-static void init_openssl() {
-  int i;
-  // Set up OpenSSL.
-  assert(openssl_locks == NULL);
-  openssl_locks = malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
-  if (!openssl_locks) {
-    perror("malloc");
-    exit(1);
-  }
-  for (i = 0; i < CRYPTO_num_locks(); ++i) {
-    pthread_mutex_init(&(openssl_locks[i]), NULL);
-  }
-  CRYPTO_THREADID_set_callback(thread_id);
-  CRYPTO_set_locking_callback(lock_or_unlock);
-}
-
-#else
-// We're using OpenSSL >=1.1, which is thread-safe by default.  We don't need to
-// do anything here.
-
-static void init_openssl() {}
-
-#endif  // OPENSSL_VERSION_NUMBER < 0x10100000L
-
 void uw_init_crypto() {
-  init_openssl();
   // Prepare signatures.
   if (uw_sig_file) {
     int fd;


### PR DESCRIPTION
The OpenSSL project has adopted a release policy that OpenSSL 1.1.1 is
the oldest release to still receive support since Jan 7, 2020[1]. For
example, high-severity CVE-2020-1967 was only fixed in OpenSSL's 1.1.1
branch[2]. (Extended support for OpenSSL 1.0.2 is purportedly still
available, but evidently starts at $15,000/year[3].)

This commit removes Ur/Web's code for supporting OpenSSL <1.1, and
replaces it with a compile-time error message advising that Ur/Web
requires OpenSSL to be configured with thread support (based on
example code at [4]).

[1] https://www.openssl.org/policies/releasestrat.html
[2] https://www.openssl.org/news/vulnerabilities.html
[3] https://www.openssl.org/support/contracts.html
[4] https://www.openssl.org/docs/manmaster/man3/CRYPTO_THREAD_lock_free.html#EXAMPLES