### PR TITLE
Slightly improved indentation in `-stop parse`.

### DIFF
--- a/src/list_util.sig
+++ b/src/list_util.sig
@@ -56,4 +56,6 @@ signature LIST_UTIL = sig
 
     val appn : (int -> unit) -> int -> unit
 
+    val join : 'a list -> 'a list -> 'a list
+
 end

--- a/src/list_util.sml
+++ b/src/list_util.sml
@@ -257,4 +257,18 @@ fun appn f n =
         iter 0
     end
 
+fun join (sep : 'a list) (ls : 'a list) =
+    let
+	val sep = rev sep
+	fun iter (acc : 'a list) (ls : 'a list) =
+	    case ls of
+		nil => rev acc
+	      | h :: t =>
+		iter (h :: (sep @ acc)) t
+    in
+	case ls of
+	    nil => []
+	  | h :: t => iter [h] t
+    end
+
 end

--- a/src/print.sig
+++ b/src/print.sig
@@ -36,8 +36,10 @@ signature PRINT = sig
     type 'a printer = 'a -> PD.pp_desc
 
     val box : PD.pp_desc list -> PD.pp_desc
+    val vbox : PD.pp_desc list -> PD.pp_desc
     val parenIf : bool -> PD.pp_desc -> PD.pp_desc
     val space : PD.pp_desc
+    val indent : int -> PD.pp_desc
 
     val p_list_sep : PD.pp_desc -> 'a printer -> 'a list printer
     val p_list : 'a printer -> 'a list printer

--- a/src/print.sml
+++ b/src/print.sml
@@ -37,12 +37,14 @@ val openOut = SM.openOut
 type 'a printer = 'a -> PD.pp_desc
 
 fun box ds = PD.hovBox (PD.PPS.Rel 1, ds)
+fun vbox ds = PD.vBox (PD.PPS.Rel 0, ds)
 fun parenIf b d =
     if b then
         box [PD.string "(", d, PD.string ")"]
     else
         d
 val space = PD.space 1
+fun indent n = PD.break { nsp = 1, offset = n }
 
 val out = SM.openOut {dst = TextIO.stdOut, wid = 70}
 val err = SM.openOut {dst = TextIO.stdErr, wid = 70}

--- a/src/source_print.sml
+++ b/src/source_print.sml
@@ -308,30 +308,34 @@ fun p_exp' par (e, _) =
                                               string "---",
                                               space,
                                               p_con' true c])
-      | ECase (e, pes) => parenIf par (box [string "case",
-                                            space,
-                                            p_exp e,
-                                            space,
-                                            string "of",
-                                            space,
-                                            p_list_sep (box [space, string "|", space])
-                                            (fn (p, e) => box [p_pat p,
-                                                               space,
-                                                               string "=>",
-                                                               space,
-                                                               p_exp e]) pes])
+      | ECase (e, pes) => parenIf par (vbox(
+                                            box [string "case",
+                                                 space,
+                                                 p_exp e,
+                                                 space,
+                                                 string "of"] ::
+                                            newline ::
+                                            ListUtil.join [newline]
+                                                          (ListUtil.mapi
+                                                               (fn (i, (p, e)) =>
+                                                                   box [(if i > 0 then string "|" else space), space,
+                                                                        box [box [p_pat p],
+                                                                        space,
+                                                                        string "=>"],
+                                                                        newline,
+                                                                        box [space, p_exp e]]) pes)))
 
       | EWild => string "_"
 
-      | ELet (ds, e) => box [string "let",
-                             newline,
-                             box [p_list_sep newline p_edecl ds],
-                             newline,
-                             string "in",
-                             newline,
-                             box [p_exp e],
-                             newline,
-                             string "end"]
+      | ELet (ds, e) => vbox [string "let",
+                              indent 1,
+                              vbox (ListUtil.join [newline] (List.map p_edecl ds)),
+                              newline,
+                              string "in",
+                              indent 1,
+                              vbox [p_exp e],
+                              newline,
+                              string "end"]
 
       | EKAbs (x, e) => box [string x,
                              space,
@@ -414,7 +418,7 @@ fun p_sgn_item (sgi, _) =
                                       p_con c]
       | SgiDatatype x => box [string "datatype",
                               space,
-                              p_list_sep (box [space, string "and", space]) p_datatype x]
+                              vbox (ListUtil.join [newline, string "and", space] (List.map p_datatype x))]
       | SgiDatatypeImp (x, ms, x') =>
         box [string "datatype",
              space,
@@ -494,7 +498,7 @@ and p_sgn (sgn, _) =
     case sgn of
         SgnConst sgis => box [string "sig",
                               newline,
-                              p_list_sep newline p_sgn_item sgis,
+                              vbox (ListUtil.join [newline] (List.map p_sgn_item sgis)),
                               newline,
                               string "end"]
       | SgnVar x => string x
@@ -504,6 +508,7 @@ and p_sgn (sgn, _) =
                                       string x,
                                       space,
                                       string ":",
+                                      space,
                                       p_sgn sgn,
                                       string ")",
                                       space,
@@ -549,7 +554,7 @@ fun p_decl ((d, _) : decl) =
                                     p_con c]
       | DDatatype x => box [string "datatype",
                             space,
-                            p_list_sep (box [space, string "and", space]) p_datatype x]
+                            vbox (ListUtil.join [newline, string "and", space] (List.map p_datatype x))]
       | DDatatypeImp (x, ms, x') =>
         box [string "datatype",
              space,
@@ -571,7 +576,7 @@ fun p_decl ((d, _) : decl) =
                             space,
                             string "rec",
                             space,
-                            p_list_sep (box [newline, string "and", space]) p_vali vis]
+                            vbox (ListUtil.join [newline, string "and", space] (List.map p_vali vis))]
 
       | DSgn (x, sgn) => box [string "signature",
                               space,
@@ -683,7 +688,7 @@ and p_str (str, _) =
     case str of
         StrConst ds => box [string "struct",
                             newline,
-                            p_list_sep newline p_decl ds,
+                            vbox (ListUtil.join [newline] (List.map p_decl ds)),
                             newline,
                             string "end"]
       | StrVar x => string x
@@ -696,6 +701,7 @@ and p_str (str, _) =
                                            string x,
                                            space,
                                            string ":",
+                                           space,
                                            p_sgn sgn,
                                            string ")",
                                            space,
@@ -708,6 +714,7 @@ and p_str (str, _) =
                                                 string x,
                                                 space,
                                                 string ":",
+                                                space,
                                                 p_sgn sgn,
                                                 string ")",
                                                 space,
@@ -723,6 +730,6 @@ and p_str (str, _) =
                                     p_str str2,
                                     string ")"]
 
-val p_file = p_list_sep newline p_decl
+fun p_file decls = vbox (ListUtil.join [newline] (List.map p_decl decls))
 
 end

--- a/tests/datatypeMod.ur
+++ b/tests/datatypeMod.ur
@@ -19,10 +19,10 @@ structure Ma : sig type t end = M
 
 structure Magain : sig datatype t = A | B end = M
 
-val page : M.t -> page = fn x => <html><body>
+val page : M.t -> page = fn x => <xml><html><body>
         Hi.
-</body></html>
+</body></html></xml>
 
-val main : unit -> page = fn () => <html><body>
-        <a link={page a2}>Link</a>
-</body></html>
+val main : unit -> page = fn () => <xml><html><body>
+        <a link={return (page a2)}>Link</a>
+</body></html></xml>

--- a/tests/datatypeP2.ur
+++ b/tests/datatypeP2.ur
@@ -5,11 +5,11 @@ val r : sum int string = Right "Hi"
 
 val show = fn x : sum int string => case x of Left _ => "Left _" | Right s => s
 
-val page = fn x => <html><body>
+val page = fn x => <xml><html><body>
         {cdata (show x)}
-</body></html>
+</body></html></xml>
 
-val main : unit -> page = fn () => <html><body>
+val main : unit -> page = fn () => <xml><html><body>
         <li><a link={page l}>Left</a></li>
         <li><a link={page r}>Right</a></li>
-</body></html>
+</body></html></xml>

--- a/tests/list.ur
+++ b/tests/list.ur
@@ -1,4 +1,4 @@
-fun isNil (t ::: Type) (ls : list t) =
+fun isNil [t ::: Type] (ls : list t) =
     case ls of
         [] => True
       | _ => False

--- a/tests/pquery.ur
+++ b/tests/pquery.ur
@@ -4,17 +4,17 @@ fun display (q : sql_query [T1 = [A = int, B = string, C = float, D = bool]] [])
         s <- query q
                 (fn fs _ => return (Some fs.T1))
                 None;
-        return <html><body>
+        return <xml><html><body>
                 {case s of
                   None => cdata "Row not found."
                 | Some s =>
-                        <body>
+                        <xml><body>
                                 A: {cdata (show _ s.A)}<br/>
                                 B: {cdata (show _ s.B)}<br/>
                                 C: {cdata (show _ s.C)}<br/>
                                 D: {cdata (show _ s.D)}<br/>
-                        </body>}
-        </body></html>
+                        </body></xml>}
+        </body></html></xml>
 
 fun lookupA (inp : {A : string}) =
         display (SELECT * FROM t1 WHERE t1.A = {readError _ inp.A})
@@ -28,7 +28,7 @@ fun lookupC (inp : {C : string}) =
 fun lookupD (inp : {D : string}) =
         display (SELECT * FROM t1 WHERE t1.D = {readError _ inp.D})
 
-fun main () : transaction page = return <html><body>
+fun main () : transaction page = return <xml><html><body>
         <lform>
                 A: <textbox{#A}/>
                 <submit action={lookupA}/>
@@ -48,4 +48,4 @@ fun main () : transaction page = return <html><body>
                 D: <textbox{#D}/>
                 <submit action={lookupD}/>
         </lform>
-</body></html>
+</body></html></xml>


### PR DESCRIPTION
* improving indentation of ASTs printed out during `-stop parse`
* fixed some test cases

This is a better version of #212, and also it uses largely the same approach as in #215.

Here's the list of commands I used for improving indentation:

```
urweb -stop parse bindpat # let-in-end
urweb -stop parse case # case-of
urweb -stop parse datatype # datatypes
urweb -stop parse datatypeP2 # mutual recursive datatypes
urweb -stop parse mutual # mutual recursive datatypes
urweb -stop parse list # list stuff
urweb -stop parse sigInModule # signatures and structures
urweb -stop parse sig_impl # signatures and structures
urweb -stop parse functor # functor
urweb -stop parse functorMania # functor
```

There are still some oddities remaining, such as
* `end` being indented same as sig/struct items,
* `case x of A => E` being broken up at `=>` incorrectly when `E` spans more than one line (so I decided to force newlines there)