### PR TITLE
"Unification variables remain": Add special case for sql errors

### DIFF
--- a/src/elab_err.sml
+++ b/src/elab_err.sml
@@ -321,6 +321,136 @@ fun p_decl env d =
         end
     end
 
+datatype rowdiffresult = MissingLeft of string * con
+                       | MissingRight of string * con
+                       | Mismatch of string * con * con
+
+fun p_diffRows (env: ElabEnv.env) (diffs: rowdiffresult list): PD.pp_desc = 
+    let
+        fun p_fieldMissing (n, con) =
+            box [ PD.string ("Missing field #" ^ n ^ ": "), p_con env con, PD.newline]
+    in
+        p_list_sep PD.newline (fn r => case r of
+                                           MissingLeft (n, con) => p_fieldMissing (n, con)
+                                         | MissingRight (n, con) => p_fieldMissing (n, con)
+                                         | Mismatch (n, c1, c2) => box [ PD.string "Type mismatch in field #", PD.string n, PD.newline
+                                                                         , PD.string "Expected: ", PD.newline
+                                                                         , p_con env c1, PD.newline
+                                                                         , PD.string "Actual: ", PD.newline
+                                                                         , p_con env c2, PD.newline ]
+                              ) diffs
+    end
+
+fun diffRows (env: ElabEnv.env) (rows1: (con * con) list) (rows2: (con * con) list): (rowdiffresult list) option =
+    let
+        fun toStrings (rows: (con * con) list) =
+            foldl
+                (fn ((n, c), acc) =>
+                    case acc of
+                        NONE => NONE
+                      | SOME acc => case n of
+                                        (CName n, _) => SOME ((n, c) :: acc)
+                                     | _ => NONE
+                )
+                (SOME [])
+                rows
+        val sort = ListMergeSort.sort (fn ((x, _), (y, _)) => String.compare (x, y) = GREATER)
+        fun compareNext rows1 rows2 acc: rowdiffresult list = 
+            case (rows1, rows2) of
+                ([], []) => acc
+              | (rows1, []) => List.revAppend (acc, (map MissingLeft rows1))
+              | ([], rows2) => List.revAppend (acc, (map MissingRight rows2))
+              | ((n1, c1) :: rest1, (n2, c2) :: rest2) => if n1 = n2
+                                                          then compareNext rest1 rest2 (if ElabOps.consEqSimple env (c1, c2)
+                                                                                        then acc
+                                                                                        else Mismatch (n1, c1, c2) :: acc)
+                                                          else
+                                                              if String.compare (n1, n2) = GREATER
+                                                              then compareNext ((n1, c1) :: rest1) rest2 (MissingRight (n2, c2) :: acc)
+                                                              else compareNext rest1 ((n2, c2) :: rest2) (MissingLeft (n1, c1) :: acc)
+    in
+        case (toStrings rows1, toStrings rows2) of
+            (SOME rows1, SOME rows2) => SOME (compareNext (sort rows1) (sort rows2) [])
+          | _ => NONE
+    end
+
+fun findTableForCunifsError (env: ElabEnv.env) (ds: Elab.decl list) =
+    let
+        fun findSqlTableMismatch a =
+            case a of
+                ECApp
+                    ((EApp
+                          ((ECApp
+                                ((ECApp
+                                      ((ECApp
+                                            ( (EModProj (_, _, "sql_from_table"), _)
+                                            , _ (* free *)
+                                            ),_)
+                                      , expectedTable (* t *)), _)
+                                , actualTable (* fs *)), _)
+                          , _ (* fieldsOf *)), _)
+                    , (CName tableName, _))
+                => (case #1 (ElabOps.reduceCon env actualTable) of
+                        CConcat
+                            ( (actualFields, _)
+                            , (CUnif _, _)) =>
+                        (case #1 (ElabOps.reduceCon env expectedTable) of
+                             CApp
+                                 ((CApp
+                                       (( CModProj (_, _, "sql_table"), _)
+                                       , (expectedFields, _)), _)
+                                 , _ (* {{Unit}} *)) =>
+                             (case (actualFields, expectedFields) of
+                                  (CRecord (_, actRows), CRecord (_, expRows)) =>
+                                  (case diffRows env actRows expRows of
+                                       NONE => NONE
+                                     | SOME res =>
+                                       let
+                                           fun skipMissingRight r =
+                                               case r of
+                                                   (* MissingRight is (in this case) not relevant *)
+                                                   (* The actual table is on the left, but if any are missing on the right *)
+                                                   (* it just means some fields of a table aren't being used, which is fine *)
+                                                   MissingRight _ => false 
+                                                 | MissingLeft _ => true
+                                                 | Mismatch _ => true
+                                           val filtered = List.filter skipMissingRight res 
+                                       in
+                                           if length filtered > 0
+                                           then SOME (tableName, filtered)
+                                           else NONE
+                                       end
+                                  )
+                                | _ => NONE
+                             )
+                           | _ => NONE
+                        )
+                      | _ => NONE)
+              | _ => NONE
+        val foundProblems = List.mapPartial (fn decl => U.Decl.search
+                                                            { kind = fn _ => NONE
+                                                            , sgn_item = fn _ => NONE
+                                                            , sgn = fn _ => NONE
+                                                            , str = fn _ => NONE
+                                                            , decl = fn _ => NONE
+                                                            , exp = findSqlTableMismatch
+                                                            , con = fn _ => NONE
+                                                            }
+                                                            decl
+                                            ) 
+                                            ds
+    in
+        print
+            (p_list
+                  (fn (tablename, rows) =>
+                      box [ PD.string ("Found problem in table " ^ tablename)
+                          , PD.newline
+                          , p_diffRows env rows
+                          ]
+                      )
+                  foundProblems)
+    end
+
 fun declError env err =
     case err of
         KunifsRemain ds =>
@@ -328,7 +458,9 @@ fun declError env err =
          eprefaces' [("Decl", p_list_sep PD.newline (p_decl env) ds)])
       | CunifsRemain ds =>
         (ErrorMsg.errorAt (lspan ds) "Some constructor unification variables are undetermined in declaration\n(look for them as \"<UNIF:...>\")";
-         eprefaces' [("Decl", p_list_sep PD.newline (p_decl env) ds)])
+         eprefaces' [("Decl", p_list_sep PD.newline (p_decl env) ds)];
+         findTableForCunifsError env ds
+        )
       | Nonpositive d =>
         (ErrorMsg.errorAt (#2 d) "Non-strictly-positive datatype declaration (could allow non-termination)";
          eprefaces' [("Decl", p_decl env d)])

--- a/src/elab_ops.sig
+++ b/src/elab_ops.sig
@@ -41,6 +41,7 @@ signature ELAB_OPS = sig
 
     val hnormCon : ElabEnv.env -> Elab.con -> Elab.con
     val reduceCon : ElabEnv.env -> Elab.con -> Elab.con
+    val consEqSimple: ElabEnv.env -> (Elab.con * Elab.con) -> bool
 
     val identity : int ref
     val distribute : int ref

--- a/src/elab_ops.sml
+++ b/src/elab_ops.sml
@@ -514,4 +514,43 @@ fun reduceCon env (cAll as (c, loc)) =
       | CUnif (nl, _, _, _, ref (Known c)) => reduceCon env (E.mliftConInCon nl c)
       | CUnif _ => cAll
 
+val consEqSimple =
+    let
+        fun ces env (c1 : con, c2 : con) =
+            let
+                val c1 = hnormCon env c1
+                val c2 = hnormCon env c2
+            in
+                case (#1 c1, #1 c2) of
+                    (CRel n1, CRel n2) => n1 = n2
+                  | (CNamed n1, CNamed n2) =>
+                    n1 = n2 orelse
+                    (case #3 (E.lookupCNamed env n1) of
+                         SOME (CNamed n2', _) => n2' = n1
+                       | _ => false)
+                  | (CModProj n1, CModProj n2) => n1 = n2
+                  | (CApp (f1, x1), CApp (f2, x2)) => ces env (f1, f2) andalso ces env (x1, x2)
+                  | (CAbs (x1, k1, c1), CAbs (_, _, c2)) => ces (E.pushCRel env x1 k1) (c1, c2)
+                  | (CName x1, CName x2) => x1 = x2
+                  | (CRecord (_, xts1), CRecord (_, xts2)) =>
+                    ListPair.all (fn ((x1, t1), (x2, t2)) =>
+                                     ces env (x1, x2) andalso ces env (t2, t2)) (xts1, xts2)
+                  | (CConcat (x1, y1), CConcat (x2, y2)) =>
+                    ces env (x1, x2) andalso ces env (y1, y2)
+                  | (CMap _, CMap _) => true
+                  | (CUnit, CUnit) => true
+                  | (CTuple cs1, CTuple cs2) => ListPair.all (ces env) (cs1, cs2)
+                  | (CProj (c1, n1), CProj (c2, n2)) => ces env (c1, c2) andalso n1 = n2
+                  | (CUnif (_, _, _, _, r1), CUnif (_, _, _, _, r2)) => r1 = r2
+
+                  | (TFun (d1, r1), TFun (d2, r2)) => ces env (d1, d2) andalso ces env (r1, r2)
+                  | (TRecord c1, TRecord c2) => ces env (c1, c2)
+                  
+                  | _ => false
+            end
+    in
+        ces
+    end
+    
+
 end


### PR DESCRIPTION
Hey,

I was thinking how I would go about explaining Ur/Web to some other people, and the first thing that came in to my mind was a list of difficult to decipher error messages. However, instead of making this list of error messages and how to deciper them, I thought maybe I could try and make some improvements to these error messages.

One of the worst ones, and also very common ones, is the "Unification variables remain" error you get when you make an error regarding fields in SQL tables. I get this error super often but it's always very tricky to figure out where exactly I went wrong. This PR adds a special case for this error. I tried it out in multiple variations and it seems to work quite well. The changes largely consist of three parts:

1. Moved Elaborate.consEqSimple to ElabOps so I can use it in ElabErr (where most of my additions are).
2. Added the special case pattern match in ElabErr. I found it extremely hard to figure out exactly how to pattern match on this and tried to structure the code as good as I could but I still find it extremely messy. I don't know if there is a better way to do this (maybe lenses?).
3. Improved Elabops.ReduceCon. In my (manual) tests I found out that eg: {Field1: int] ++ <Unif> ++ {Field2: Int} wasn't getting reduced nicely to {Field1: int, Field2: int} ++ <Unif> so I tried to improve reduceCon. I think it's a pretty good "algorithm" now, but ideally I would have written some tests for it to convince myself it will handle all cases of nested concats. It definitely improved the results of my tests, but I'm not sure if it's now a 100% correct algorithm so all records inside nested CConcat's will always get added nicely.

An example:
**A. Testcase** (Table has field Field1, but we made a mistake and try to show Field2).
```
table mytable : { Field1 : string }

fun page () =
    found <- oneRow1 (SELECT * FROM mytable);
    return <xml>
      <body>{[found.Field2]}</body>
    </xml>
```

**B. Original error:**
```
- /home/simon/ur-proj/test/test.ur:3:0: (to 8:5) Some constructor unification variables are undetermined in declaration
(look for them as "<UNIF:...>")
Decl: 

.....
val rec
 page : {} -> transaction (xml ([Html = ()]) ([]) ([])) =
  fn $x : {} =>
   case $x of
    {} =>
     Basis.bind [transaction]
      [$(([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>)]
      [xml ([Html = ()]) ([]) ([])] Basis.transaction_monad
      (oneRow1 [#Mytable] [([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]
        (Basis.sql_query [[]] [[]]
          [[Mytable = ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]]
          [[Mytable =
             (fn fields :: ({Type} * {Type}) => fields.1)
              (([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>, [])]] [[]]
          {Rows =
            Basis.sql_query1 [[]] [[]]
             [[Mytable = ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]]
             [[Mytable = ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]]
             [[Mytable =
                (fn fields :: ({Type} * {Type}) => fields.1)
                 (([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>, [])]]
             [[]] [[]]
             {Distinct = Basis.False, 
               From =
                Basis.sql_from_table [[]] [sql_table ([Field1 = string]) ([])]
                 [([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>] _
                 [#Mytable] UNBOUND_NAMED2298, 
               Where =
                Basis.sql_inject
                 [([]) ++
                   [Mytable =
                     ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]] [[]]
                 [[]] [bool] Basis.sql_prim [bool] Basis.sql_bool Basis.True, 
               GroupBy =
                Basis.sql_subset_all
                 [[Mytable =
                    ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]], 
               Having =
                Basis.sql_inject
                 [([]) ++
                   [Mytable =
                     ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]]
                 [([]) ++
                   [Mytable =
                     ([Field2 = <UNIF:U83::Type>]) ++ <UNIF:U82::{Type}>]] [[]]
                 [bool] Basis.sql_prim [bool] Basis.sql_bool Basis.True, 
               SelectFields =
                Bas
.....
```

**C. New error** (Appended after previous wall of text):
```
Found problem in table Mytable
 Missing field #Field2: <UNIF:U83::Type>
```

