### PR TITLE
Unification error: Add special case for mismatch between CApp(a, b) and b

### DIFF
--- a/src/elab_err.sig
+++ b/src/elab_err.sig
@@ -56,6 +56,7 @@ signature ELAB_ERR = sig
              CKind of Elab.kind * Elab.kind * ElabEnv.env * kunify_error
            | COccursCheckFailed of Elab.con * Elab.con
            | CIncompatible of Elab.con * Elab.con
+           | CMissingCApp of Elab.con (* Missing applied con *) * Elab.con (* Wrapped *)
            | CExplicitness of Elab.con * Elab.con
            | CKindof of Elab.kind * Elab.con * string
            | CRecordFailure of Elab.con * Elab.con * (Elab.con * Elab.con * Elab.con * (ElabEnv.env * cunify_error) option) option

--- a/src/elab_err.sml
+++ b/src/elab_err.sml
@@ -138,10 +138,10 @@ fun cunifyError env err : unit =
                    ("Need", p_con env c2)]
       | CMissingCApp (c1, c2) =>
         print
-            (box
-                 [ box [PD.string "Missing a constructor application:", PD.newline]
+            (vbox
+                 [ PD.string "Missing a constructor application:", PD.newline
                  , vbox [indent 2, p_con env c1, PD.newline, PD.newline]
-                 , box [PD.string "On: ", PD.newline]
+                 , PD.string "On: ", PD.newline
                  , vbox [indent 2, p_con env c2, PD.newline, PD.newline]])
       | CExplicitness (c1, c2) =>
         eprefaces "Differing constructor function explicitness"

--- a/src/elab_err.sml
+++ b/src/elab_err.sml
@@ -112,6 +112,7 @@ datatype cunify_error =
          CKind of kind * kind * E.env * kunify_error
        | COccursCheckFailed of con * con
        | CIncompatible of con * con
+       | CMissingCApp of con (* Missing applied con *) * con (* Wrapped *)
        | CExplicitness of con * con
        | CKindof of kind * con * string
        | CRecordFailure of con * con * (con * con * con * (E.env * cunify_error) option) option
@@ -135,6 +136,13 @@ fun cunifyError env err : unit =
         eprefaces "Incompatible constructors"
                   [("Have", p_con env c1),
                    ("Need", p_con env c2)]
+      | CMissingCApp (c1, c2) =>
+        print
+            (box
+                 [ box [PD.string "Missing a constructor application:", PD.newline]
+                 , vbox [indent 2, p_con env c1, PD.newline, PD.newline]
+                 , box [PD.string "On: ", PD.newline]
+                 , vbox [indent 2, p_con env c2, PD.newline, PD.newline]])
       | CExplicitness (c1, c2) =>
         eprefaces "Differing constructor function explicitness"
                   [("Have", p_con env c1),


### PR DESCRIPTION
Another error I run into often that is often hard to decipher is missing a return statement to get my result back into the right monad: transaction or signal mostly. This PR adds a new unification error CMissingCApp (I couldn't figure out a better name but I'm open to suggestions!). 

I couldn't keep it only in ElabErr like the previous PR. I had to actually look for the situation in the unification process itself and throw a new error in that case, I hope that's OK. I'm also unsure about the wording of the new error message, it can probably use some improvements.

I first tried to add it in the big pattern matching clause of unifyCons'', but that didn't work out. One of the higher up patterns (I believe it was the `(L'.CApp (d1, r1), L'.CApp (d2, r2))` pattern) didn't allow me to find this specific pattern.

Example:
A. Urweb code
```
fun page2 (): transaction page =
    <xml><body></body></xml>
```

B. Original error:
```
 Have:  val page2 : {} -> xml ([Html = ()]) <UNIF:F::{Type}> ([])
 Need:  val page2 : unit -> transaction (xml ([Html = ()]) ([]) ([]))
Con 1:  {} -> xml ([Html = ()]) <UNIF:F::{Type}> ([])
Con 2:  {} -> transaction (xml ([Html = ()]) ([]) ([]))
Incompatible constructors
Have:  xml ([Html = ()]) <UNIF:F::{Type}>
Need:  transaction
```

C. New error (Full):
```
 Have:  val page2 : {} -> xml ([Html = ()]) ([]) ([])
 Need:  val page2 : unit -> transaction (xml ([Html = ()]) ([]) ([]))
Con 1:  {} -> xml ([Html = ()]) ([]) ([])
Con 2:  {} -> transaction (xml ([Html = ()]) ([]) ([]))
Missing a constructor application:

  transaction

On: 

  xml ([Html = ()]) ([]) ([])


```

In this case the original error is pretty readable, but in real code, this can get quite hairy once the terms get bigger, spanning multiple lines. In that case, this specific check will be much more readable I think. It might be better to put the missing constructor all the way at the end of the error, instead of the "wrapped" term (as this might get pretty big and drown out the "transaction" in this example), but that's a pretty small change if that ends up being a better idea.