### PR TITLE
Fix "Too deep

### DIFF
--- a/src/elaborate.sml
+++ b/src/elaborate.sml
@@ -1784,7 +1784,7 @@ fun exhaustive (env, t, ps, loc) =
 
                     val (t1, args) = unapp (hnormCon env q1, [])
                     val t1 = hnormCon env t1
-                    fun doSub t = foldl (fn (arg, t) => subConInCon env (0, arg) t) t args
+                    fun doSub t = (ListUtil.foldli (fn (i, arg, t) => (subConInCon env (length args - i, arg) t)) t args)
 
                     fun dtype (dtO, names) =
                         let


### PR DESCRIPTION
This is my attempt at fixing a very frustrating error I get now and then when using the "either" datatype. I use it all over the place to return a value that can also be an error.

Example Ur/Web code:
```
datatype either a b = Left of a
                    | Right of b

fun page2 (): transaction page =
    return <xml><body>
      {[case Left 1 of
          Left i => ""
        | Right j => ""
      ]}
    </body></xml>
```

Previous error:
```
- /home/simon/ur-proj/test/main.ur:1:~4: (to 2:32) Substitution in constructor is blocked by a too-deep unification variable
Replacement:  int
       Body:  <UNIF:U31::Type>
```

New error:
```
- /home/simon/ur-proj/test/main.ur:4:0: (to 11:5) Some constructor unification variables are undetermined in declaration
(look for them as "<UNIF:...>")
Decl: 

.....
val rec
 page2 : {} -> transaction (xml ([Html = ()]) ([]) ([])) =
  fn $x : {} =>
   case $x of
    {} =>
     return [transaction] [xml ([Html = ()]) ([]) ([])] Basis.transaction_monad
      (Basis.tag [[]]
        [[Data = data_attr, Id = id, Title = string, Onload = transaction {}, 
           Onunload = transaction {}, Onhashchange = transaction {}, 
           Onblur = transaction {}, Onfocus = transaction {}, 
           Onclick = mouseEvent -> transaction unit, 
           Oncontextmenu = mouseEvent -> transaction unit, 
           Ondblclick = mouseEvent -> transaction unit, 
           Onmousedown = mouseEvent -> transaction unit, 
           Onmouseenter = mouseEvent -> transaction unit, 
           Onmouseleave = mouseEvent -> transaction unit, 
           Onmousemove = mouseEvent -> transaction unit, 
           Onmouseout = mouseEvent -> transaction unit, 
           Onmouseover = mouseEvent -> transaction unit, 
           Onmouseup = mouseEvent -> transaction unit, 
           Onkeydown = keyEvent -> transaction unit, 
           Onkeypress = keyEvent -> transaction unit, 
           Onkeyup = keyEvent -> transaction unit, Onresize = transaction {}, 
           Onscroll = transaction {}]] [[Html = ()]]
        [[Dyn = (), MakeForm = (), Body = ()]] [[]] [[]] [[]] [[]] Basis.null
        (Basis.None [signal css_class]) Basis.noStyle
        (Basis.None [signal css_style]) {} (body {})
        (Basis.join [[Dyn = (), MakeForm = (), Body = ()]] [[]] [[]] [[]]
          (Basis.cdata [[Dyn = (), MakeForm = (), Body = ()]] [[]] "\n")
          (Basis.join [[Dyn = (), MakeForm = (), Body = ()]] [[]] [[]] [[]]
            (Basis.cdata [[Dyn = (), MakeForm = (), Body = ()]] [[]] "      ")
            (Basis.join [[Dyn = (), MakeForm = (), Body = ()]] [[]] [[]] [[]]
              (Top.txt [string] [[Dyn = (), MakeForm = (), Body = ()]] [[]]
                Basis.show_string
                (case UNBOUND_NAMED2302 [int] [<UNIF:U31::Type>] 1 of
                  UNBOUND_NAMED2302 i => "" | UNBOUND_NAMED2303 j => ""))
              (Basis.join [[Dyn = (), MakeForm = (), Body = ()]] [[]] [[]] [[]]
                (Basis.cdata [[Dyn = (), MakeForm = (), Body = ()]] [[]] "\n")
                (Basis.cdata [[Dyn = (), MakeForm = (), Body = ()]] [[]] "    "))))))

.....
```

The old error is often very difficult to fix, as it's often not clear what exactly is causing it. The new error is (in my opinion) the correct one: The compiler can't figure out what the second type parameter should be in this case, so the unification variable stayed undefined. 

Side note: The new error is in some ways harder to read, but that's mostly because of the XML encoding and it being so verbosely printed. That's maybe something to fix later...

As for the implementation: I actually don't know what the code here is doing... I tried hard to understand it, but I just don't understand what subConInCon and liftConInCon are supposed to do... I just looked at the similar code in elabPat and applied the same pattern here, but I'm really not sure if this is 100% correct.

Simon