### PR TITLE
fixed mlton -mlb-path-var '[...] strange mlb path var: [...]' problem

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,8 @@ mlton-tc: bin/urwebtc
 
 clean-local:
 	rm -f bin/urweb src/urweb.mlton.* \
-		src/urweb.cm src/urweb.mlb xml/parse xml/entities.sml
+		src/urweb.cm src/urweb.mlb xml/parse xml/entities.sml \
+		mlb-path-map
 	rm -rf .cm src/.cm
 
 src/urweb.cm: src/prefix.cm src/sources
@@ -55,18 +56,25 @@ MLTON = mlton
 #	MLTON += -profile $(PROFILE)
 #endif
 
+mlb-path-map: Makefile
+	echo SRC $(abs_srcdir)/src > $@
+	echo BUILD $(abs_builddir)/src >> $@
+
 bin/urweb: src/compiler.mlb xml/entities.sml \
 		src/urweb.mlb $(srcdir)/src/*.sig $(srcdir)/src/*.sml src/config.sml \
 		src/urweb.mlton.lex.sml \
-		src/urweb.mlton.grm.sig src/urweb.mlton.grm.sml
+		src/urweb.mlton.grm.sig src/urweb.mlton.grm.sml \
+		mlb-path-map
 	mkdir -p bin
-	$(MLTON) $(MLTONARGS) -mlb-path-var 'SRC $(abs_srcdir)/src' -mlb-path-var 'BUILD $(abs_builddir)/src' -output $@ $<
+	$(MLTON) $(MLTONARGS) -mlb-path-map mlb-path-map -output $@ $<
+
 bin/urwebtc: src/compiler.mlb xml/entities.sml \
 		src/urweb.mlb $(srcdir)/src/*.sig $(srcdir)/src/*.sml src/config.sml \
 		src/urweb.mlton.lex.sml \
-		src/urweb.mlton.grm.sig src/urweb.mlton.grm.sml
+		src/urweb.mlton.grm.sig src/urweb.mlton.grm.sml \
+		mlb-path-map
 	mkdir -p bin
-	$(MLTON) $(MLTONARGS) -prefer-abs-paths true -show-def-use compiler.du -stop tc -mlb-path-var 'SRC $(abs_srcdir)/src' -mlb-path-var 'BUILD $(abs_builddir)/src' -output $@ $<
+	$(MLTON) $(MLTONARGS) -prefer-abs-paths true -show-def-use compiler.du -stop tc -mlb-path-map mlb-path-map -output $@ $<
 
 xml/entities.sml: xml/parse xml/xhtml-lat1.ent xml/xhtml-special.ent xml/xhtml-symbol.ent
 	$^ > $@


### PR DESCRIPTION
When building on my Gentoo system with 'MLton 20180207' I get this error message:

    [...]
    mlton  -mlb-path-var 'SRC /home/sielenk/UrWeb/urweb/src' -mlb-path-var 'BUILD /home/sielenk/UrWeb/urweb/src' -output bin/urweb src/compiler.mlb
    unhandled exception: Fail: strange mlb path var: SRC
    make[1]: *** [Makefile:896: bin/urweb] Error 1
    [...]

I was unable to resolve this problem with changing the quoting in the command line but finally managed to get it working again by using the mlb-path-map file.

Feel free to ignore this pull request, since I did not try it on any other system.
But I would like this to be discoverable closer to your repo in case someone stumbles on the same problem.

Best regards,
Marvin 