### PR TITLE
checkProperty: Accept CSS properties starting with hyphens

### DIFF
--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -3378,17 +3378,24 @@ function css_url(s) {
 
 function property(s) {
     var chars = strSplit(s);
-    
+
     if (chars.length <= 0)
         er("Empty CSS property");
 
-    if (chars[0] > maxCh || (!isLower(chars[0]) && chars[0] != '_'))
+    // See https://www.w3.org/TR/CSS21/grammar.html#scanner, rule `ident`
+    function nmstart(c) {
+      return c <= maxCh && (isAlpha(c) || c == '_')
+    }
+    function nmchar(c) {
+      return c <= maxCh && (isAlpha(c) || isDigit(c) || c == '_' || c == '-')
+    }
+
+    if (!(nmstart(chars[0]) || chars.length > 1 && chars[0] == '-' && nmstart(chars[1])))
         er("Bad initial character in CSS property");
 
     for (var i = 0; i < chars.length; ++i) {
-        var c = chars[i];
-        if (c > maxCh || (!isLower(c) && !isDigit(c) && c != '_' && c != '-'))
-            er("Disallowed character in CSS property");
+        if (!(nmchar(chars[i])))
+	    er("Disallowed character in CSS property");
     }
 
     return s;

--- a/src/mono_opt.sml
+++ b/src/mono_opt.sml
@@ -183,9 +183,16 @@ val checkCssUrl = CharVector.all (fn ch => Char.isAlphaNum ch
                                            orelse ch = #"&"
                                            orelse ch = #"="
                                            orelse ch = #"#")
-fun checkProperty s = size s > 0
-                      andalso (Char.isLower (String.sub (s, 0)) orelse String.sub (s, 0) = #"_")
-                      andalso CharVector.all (fn ch => Char.isLower ch orelse Char.isDigit ch orelse ch = #"_" orelse ch = #"-") s
+fun checkProperty s =
+  (* See https://www.w3.org/TR/CSS21/grammar.html#scanner, rule `ident` *)
+  let
+    fun nmstart ch = Char.isAlpha ch orelse ch = #"_"
+    fun nmchar ch = nmstart ch orelse Char.isDigit ch orelse ch = #"-"
+  in
+    size s > 0
+    andalso (nmstart (String.sub (s, 0)) orelse size s > 1 andalso String.sub (s, 0) = #"-" andalso nmstart (String.sub (s, 1)))
+    andalso CharVector.all nmchar s
+  end
 
 fun exp e =
     case e of

--- a/tests/css.ur
+++ b/tests/css.ur
@@ -13,4 +13,5 @@ fun main () = return <xml><body>
   <span style="background: url(http://www.google.com/image.png)">C</span>
   <span style="background: url('http://www.google.com/image.png') red 10% 66px">D</span>
   <span style="color: red; width: 90 green; background: url(http://www.google.com/foo.jpg);">C</span>
+  <span style="-moz-hyphens: auto">Properties with dashes</span>
 </body></xml>

--- a/tests/styleRt.ur
+++ b/tests/styleRt.ur
@@ -16,14 +16,16 @@ fun main () =
       Property: <ctextbox source={prop}/><br/>
       Value: <ctextbox source={valu}/><br/>
       URL: <ctextbox source={url}/><br/>
-      <button value="Go!" onclick={prop <- get prop;
-                                   valu <- get valu;
-                                   url <- get url;
-                                   set xm <xml><span style={oneProperty
-                                                                (oneProperty noStyle (value (property prop) (atom valu)))
-                                                                (value (property "background") (css_url (bless url)))}>
-                                     Teeeest
-                                   </span></xml>}/>
+      <button value="Go!" onclick={fn _ =>
+	prop <- get prop;
+        valu <- get valu;
+        url <- get url;
+        set xm <xml><span style={
+	  oneProperty
+            (oneProperty noStyle (value (property prop) (atom valu)))
+            (value (property "background") (css_url (bless url)))}>
+          Teeeest
+        </span></xml>}/>
       <hr/>
       <dyn signal={signal xm}/>
       <hr/>


### PR DESCRIPTION
following the CSS 2.1 grammar.

(The CSS 3 grammar has even more stuff, such as two hyphens to start
with, for what looks like “variables”, but it wasn’t clear to me if
that feature should be exposed when Ur/Web provides better ways to
parametrize definitions.)