### PR TITLE
Don't keep postgres connections open unnecessarily

### DIFF
--- a/src/c/fastcgi.c
+++ b/src/c/fastcgi.c
@@ -552,7 +552,7 @@ static void *worker(void *data) {
 }
 
 static void help(char *cmd) {
-  printf("Usage: %s [-t <thread-count>]\n", cmd);
+  printf("Usage: %s [-t <thread-count>] [-c]\nThe -c option disables the client pruner thread.", cmd);
 }
 
 static void sigint(int signum) {
@@ -568,6 +568,8 @@ int main(int argc, char *argv[]) {
   struct sockaddr_in their_addr; // connector's address information
   socklen_t sin_size;
   int nthreads = 1, i, *names, opt;
+  int run_client_pruner = 1;
+
   char *fwsa = getenv("FCGI_WEB_SERVER_ADDRS"), *nthreads_s = getenv("URWEB_NUM_THREADS");
  
   if (nthreads_s) {
@@ -583,12 +585,16 @@ int main(int argc, char *argv[]) {
   signal(SIGUSR1, sigint);
   signal(SIGTERM, sigint);
 
-  while ((opt = getopt(argc, argv, "ht:")) != -1) {
+  while ((opt = getopt(argc, argv, "htc:")) != -1) {
     switch (opt) {
     case '?':
       fprintf(stderr, "Unknown command-line option");
       help(argv[0]);
       return 1;
+
+    case 'c':
+      run_client_pruner = 0;
+      break;
 
     case 'h':
       help(argv[0]);
@@ -603,6 +609,7 @@ int main(int argc, char *argv[]) {
       }
       break;
 
+
     default:
       fprintf(stderr, "Unexpected getopt() behavior\n");
       return 1;
@@ -616,7 +623,7 @@ int main(int argc, char *argv[]) {
 
   sin_size = sizeof their_addr;
 
-  {
+  if (run_client_pruner == 1) {
     pthread_t thread;
 
     pruner_data *pd = (pruner_data *)malloc(sizeof(pruner_data));

--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -654,6 +654,9 @@ void *uw_get_db(uw_context ctx) {
   return ctx->db;
 }
 
+void uw_close(uw_context ctx) {
+  ctx->app->db_close(ctx);
+}
 
 uw_loggers* uw_get_loggers(struct uw_context *ctx) {
   return ctx->loggers;
@@ -735,9 +738,6 @@ failure_kind uw_begin_init(uw_context ctx) {
   return r;
 }
 
-void uw_close(uw_context ctx) {
-  ctx->app->db_close(ctx);
-}
 
 uw_Basis_string uw_Basis_requestHeader(uw_context ctx, uw_Basis_string h) {
   if (ctx->get_header)


### PR DESCRIPTION
This is a change I've done about 2.5 months ago to make the sql connection handling of urweb a little more efficient (and have been using it in production ever since). The main change is that sql connections for tasks are not kept alive indefinitely, but rather are created and closed when necessary (unless the task has to run every minute or more). Secondly I also added an option to disable the client-pruner thread. This is unnecessary if you don't use the client functionality of urweb.

This again comes out of my desire to run a bunch of urweb processes next to each other. This change changes nothing functionality, it just optimizes memory use.

If you don't want to merge this change, no problem, I'll keep it around in my fork, but I thought I'd at least propose to upstream it.