### PR TITLE
Fix 'expected identifier or ( before numeric constant' error for true/false in GCC 11.2.0

### DIFF
--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -3119,13 +3119,13 @@ char *uw_Basis_sqlifyTimeN(uw_context ctx, uw_Basis_time *t) {
 }
 
 char *uw_Basis_ensqlBool(uw_Basis_bool b) {
-  static uw_Basis_int true = 1;
-  static uw_Basis_int false = 0;
+  static uw_Basis_int t = 1;
+  static uw_Basis_int f = 0;
 
   if (!b)
-    return (char *)&false;
+    return (char *)&f;
   else
-    return (char *)&true;
+    return (char *)&t;
 }
 
 uw_Basis_string uw_Basis_intToString(uw_context ctx, uw_Basis_int n) {
@@ -3223,13 +3223,13 @@ uw_Basis_char *uw_Basis_stringToChar(uw_context ctx, uw_Basis_string s) {
 
 uw_Basis_bool *uw_Basis_stringToBool(uw_context ctx, uw_Basis_string s) {
   (void)ctx;
-  static uw_Basis_bool true = uw_Basis_True;
-  static uw_Basis_bool false = uw_Basis_False;
+  static uw_Basis_bool t = uw_Basis_True;
+  static uw_Basis_bool f = uw_Basis_False;
 
   if (!strcasecmp (s, "True"))
-    return &true;
+    return &t;
   else if (!strcasecmp (s, "False"))
-    return &false;
+    return &f;
   else
     return NULL;
 }


### PR DESCRIPTION
Fixes

```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../../include/urweb -I./../../include/urweb -I/usr/include -Wall -Wunused-parameter -Werror -Wno-format-security -Wno-deprecated-declarations -U_FORTIFY_SOURCE -g -O2 -MT urweb.lo -MD -MP -MF .deps/urweb.Tpo -c urweb.c  -fPIC -DPIC -o .libs/urweb.o
In file included from /usr/include/unicode/utf8.h:37,
                 from urweb.c:23:
urweb.c: In function ‘uw_Basis_ensqlBool’:
urweb.c:3122:23: error: expected identifier or ‘(’ before numeric constant
 3122 |   static uw_Basis_int true = 1;
      |                       ^~~~
urweb.c:3123:23: error: expected identifier or ‘(’ before numeric constant
 3123 |   static uw_Basis_int false = 0;
      |                       ^~~~~
urweb.c:3126:20: error: lvalue required as unary ‘&’ operand
 3126 |     return (char *)&false;
      |                    ^
urweb.c:3128:20: error: lvalue required as unary ‘&’ operand
 3128 |     return (char *)&true;
      |                    ^
In file included from /usr/include/unicode/utf8.h:37,
                 from urweb.c:23:
urweb.c: In function ‘uw_Basis_stringToBool’:
urweb.c:3226:24: error: expected identifier or ‘(’ before numeric constant
 3226 |   static uw_Basis_bool true = uw_Basis_True;
      |                        ^~~~
urweb.c:3227:24: error: expected identifier or ‘(’ before numeric constant
 3227 |   static uw_Basis_bool false = uw_Basis_False;
      |                        ^~~~~
urweb.c:3230:12: error: lvalue required as unary ‘&’ operand
 3230 |     return &true;
      |            ^
urweb.c:3232:12: error: lvalue required as unary ‘&’ operand
 3232 |     return &false;
      |            ^
urweb.c: In function ‘uw_Basis_ensqlBool’:
urweb.c:3129:1: error: control reaches end of non-void function [-Werror=return-type]
 3129 | }
      | ^
urweb.c: In function ‘uw_Basis_stringToBool’:
urweb.c:3235:1: error: control reaches end of non-void function [-Werror=return-type]
 3235 | }
      | ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:535: urweb.lo] Error 1
make[1]: Leaving directory 'urweb/src/c'
make: *** [Makefile:432: all-recursive] Error 1
```

GCC 11.2.0 on Ubuntu 22.04 LTS