### PR TITLE
These changes permit filesystem paths for 3 MLton programs (`mlton`, …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,9 @@ SRCLIB    = @SRCLIB@
 INCLUDE   = @INCLUDE@
 SITELISP  = @SITELISP@
 VERSION   = @VERSION@
+MLTON     = @MLTON@
+MLLEX     = @MLLEX@
+MLYACC    = @MLYACC@
 MLTONARGS = @MLTONARGS@
 
 LIB_UR   = $(SRCLIB)/ur
@@ -40,12 +43,10 @@ src/urweb.mlton.grm: src/urweb.grm
 	cp $< $@
 
 src/urweb.mlton.lex.sml: src/urweb.mlton.lex
-	mllex $<
+	$(MLLEX) $<
 
 src/urweb.mlton.grm.sig src/urweb.mlton.grm.sml: src/urweb.mlton.grm
-	mlyacc $<
-
-MLTON = mlton
+	$(MLYACC) $<
 
 #ifdef DEBUG
 #	MLTON += -const 'Exn.keepHistory true'

--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,9 @@ AC_SUBST(SRCLIB)
 AC_SUBST(INCLUDE)
 AC_SUBST(SITELISP)
 AC_SUBST(CCARGS)
+AC_SUBST(MLTON)
+AC_SUBST(MLLEX)
+AC_SUBST(MLYACC)
 AC_SUBST(MLTONARGS)
 AC_SUBST(PGHEADER)
 AC_SUBST(MSHEADER)
@@ -146,6 +149,9 @@ Ur/Web configuration:
   site-lisp directory: SITELISP       $SITELISP
   C compiler:          CC             $CC
   Extra CC args:       CCARGS         $CCARGS
+  MLton program:       MLTON          $MLTON
+  MLLex program:       MLLEX          $MLLEX
+  MLYacc program:      MLYACC         $MLYACC
   Extra MLTON args:    MLTONARGS      $MLTONARGS
   Postgres C header:   PGHEADER       $PGHEADER
   MySQL C header:      MSHEADER       $MSHEADER


### PR DESCRIPTION
…`mllex`, `mlyacc`) to be specified to `configure`, to be used during building.

(A reason someone would want this fix is when they're juggling multiple versions/builds of MLton on a development workstation, or even on a production server.  They'll want to reduce the chance of some part of the system accidentally getting an unexpected version/build, or parts from multiple versions/builds.)

Example using this fix:

```console
$ sh autogen.sh

$ ./configure \
    --prefix=/usr/local/urweb-temp \
    MLTON=/usr/local/mlton-20210117-1/bin/mlton \
    MLLEX=/usr/local/mlton-20210117-1/bin/mllex \
    MLYACC=/usr/local/mlton-20210117-1/bin/mlyacc

$ make

$ sudo make install

$ /usr/local/urweb-temp/bin/urweb -version
The Ur/Web compiler, version 20200209 + d3ea815ed5b652763cc1ee252cfe60e244962053

$ LD_LIBRARY_PATH="/usr/local/urweb-temp/lib" ./demo/hello.exe
Database connection initialized.
Starting the Ur/Web native HTTP server, which is intended for use
ONLY DURING DEVELOPMENT.  You probably want to use one of the other backends,
behind a production-quality HTTP server, for a real deployment.

Listening on port 8080....
Database connection initialized.
Database connection initialized.
Accepted connection.
Handling connection with thread #0.
Serving URI /Hello/main....
^CExiting....
```

I haven't tested it beyond that.

(Maybe `configure` should also have an `--mlton-prefix` argument, but this fix doesn't add that.)