### PR TITLE
Correct float pretty-printing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -148,4 +148,9 @@ test:
 	else \
 		echo "Skipped IPv6 tests."; \
 	fi
+	bin/urweb -boot -noEmacs tests/float2
+	tests/float2.exe -q -a 127.0.0.1 & echo $$! >$(TESTPID)
+	sleep 1
+	(curl -s 'http://localhost:8080/main' | grep -Fq 0.6) || (kill `cat $(TESTPID)`; echo "Test 'float2' failed"; /bin/false)
+	kill `cat $(TESTPID)`
 	echo Tests succeeded.

--- a/src/prim.sml
+++ b/src/prim.sml
@@ -38,10 +38,20 @@ datatype t =
 open Print.PD
 open Print
 
+(* MLton's Real64.toString prints doubles that have no fractional part the same
+ * as integers. This doesn't play well with C, since C won't convert integers to
+ * doubles unless it absolutely has to; for example, it will evaluate 3/5 to 0
+ * instead of 0.6. To avoid this, always print doubles in scientific notation,
+ * which forces the C parser to parse them as doubles. Print with 17 significant
+ * digits (16 after the decimal place), since that's the maximum precision of a
+ * double.
+ *)
+val realToString = Real64.fmt (StringCvt.SCI (SOME 16))
+
 fun p_t t =
     case t of
         Int n => string (Int64.toString n)
-      | Float n => string (Real64.toString n)
+      | Float n => string (realToString n)
       | String (_, s) => box [string "\"", string (String.toString s), string "\""]
       | Char ch => box [string "#\"", string (String.toString (String.str ch)), string "\""]
 
@@ -57,7 +67,7 @@ fun int2s' n =
     else
         Int64.toString n
 
-val float2s = String.translate (fn #"~" => "-" | ch => str ch) o Real64.toString
+val float2s = String.translate (fn #"~" => "-" | ch => str ch) o realToString
 
 fun toString t =
     case t of

--- a/tests/float2.ur
+++ b/tests/float2.ur
@@ -1,0 +1,15 @@
+(* Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *)
+val main : transaction page = return <xml><body>{[3.0 / 5.0]}</body></xml>


### PR DESCRIPTION
MLton’s `Real64.toString` prints doubles that have no fractional part the same as integers. This doesn’t play well with C, since C won’t convert integers to doubles unless it absolutely has to; for example, it will evaluate `3 / 5` to `0` instead of `0.6`. To avoid this, always print doubles in scientific notation, which forces the C parser to parse them as doubles.