### PR TITLE
Allow void datatype declaration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {self, nixpkgs, flake-utils} :
+    flake-utils.lib.eachSystem ["x86_64-linux"]
+      (system:
+        let
+          pkgs = import nixpkgs { system = system; };
+        in
+          {
+            defaultPackage = (import ./default.nix {
+              pkgs = pkgs;
+            });
+          }
+      );
+}

--- a/src/urweb.grm
+++ b/src/urweb.grm
@@ -708,6 +708,7 @@ decl   : CON SYMBOL cargl2 kopt EQ cexp (let
        | FFI SYMBOL ffi_modes COLON cexp([(DFfi (SYMBOL, ffi_modes, cexp), s (FFIleft, cexpright))])
 
 dtype  : SYMBOL dargs EQ barOpt dcons   (SYMBOL, dargs, dcons)
+       | SYMBOL dargs                   (SYMBOL, dargs, [])
 
 dtypes : dtype                          ([dtype])
        | dtype AND dtypes               (dtype :: dtypes)


### PR DESCRIPTION
**TL;DR**: Can't do math without a zero.

### Background

Void datatype declarations are useful in many ways. I think my concrete use case is quite compelling: I have a frontend and a backend which are two separate apps with shared libraries. The libraries expose some internals, guarded by a  type `internal`. This has a definition in my backend of the form `datatype internal = SomeConstructor`, allowing internal functions to be called. The frontend however, has just a void definition `datatype internal`, making it impossible to call the internals. This patch enables the parsing of such a void definition. AFAICT this simple change doesn't break anything. No new conflicts are introduced in the parser.