### PR TITLE
Runtime: set `transaction_started = 0` after db `COMMIT`

### DIFF
--- a/src/c/urweb.c
+++ b/src/c/urweb.c
@@ -3761,6 +3761,8 @@ int uw_commit(uw_context ctx) {
     }
   }
 
+  ctx->transaction_started = 0;
+
   for (i = ctx->used_transactionals-1; i >= 0; --i)
     if (ctx->transactionals[i].rollback == NULL)
       if (ctx->transactionals[i].commit) {


### PR DESCRIPTION
This fixes #273 for me.

I am not very familiar with ur/web internals and I suppose I was lucky with this fix working, because after digging deeper, I am quite confused as to how a commit-phase error triggers `ctx->app->db_rollback` (which causes the crash described in #273)

The only places I can see that run `ctx->app->db_rollback` are `uw_expunge` and `uw_rollback`, but I don't see how either of these would be reached at this point here: https://github.com/urweb/urweb/blob/master/src/c/urweb.c#L3764-L3785