### PR TITLE
Mouse events overhaul

### DIFF
--- a/lib/js/urweb.js
+++ b/lib/js/urweb.js
@@ -1600,7 +1600,15 @@ function uw_mouseEvent() {
             _ShiftKey : firstGood(ev.shiftKey, false),
             _AltKey : firstGood(ev.altKey, false),
             _MetaKey : firstGood(ev.metaKey, false),
-            _Button : ev.button == 2 ? "Right" : ev.button == 1 ? "Middle" : "Left"};
+            _Buttons :
+               {
+                  _Left   : (ev.buttons & 1) !== 0,
+                  _Right  : (ev.buttons & 2) !== 0,
+                  _Middle : (ev.buttons & 4) !== 0
+               }
+           };
+            // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+            // event.button is not defined for all mouse events
 }
 
 function uw_keyEvent() {

--- a/lib/ur/basis.urs
+++ b/lib/ur/basis.urs
@@ -859,14 +859,23 @@ val title : unit -> tag [Data = data_attr] head [] [] []
 val link : unit -> tag [Data = data_attr, Id = id, Rel = string, Title = string, Typ = string, Href = url, Media = string, Integrity = string, Crossorigin = string, Sizes = string] head [] [] []
 val meta : unit -> tag [Nam = meta, Content = string, Id = id] head [] [] []
 
-datatype mouseButton = Left | Right | Middle
-
-type mouseEvent = { ScreenX : int, ScreenY : int, ClientX : int, ClientY : int, OffsetX : int, OffsetY : int,
-                    CtrlKey : bool, ShiftKey : bool, AltKey : bool, MetaKey : bool,
-                    Button : mouseButton }
+type mouseEvent =
+       {
+              ScreenX : int,
+              ScreenY : int,
+              ClientX : int,
+              ClientY : int,
+              OffsetX : int,
+              OffsetY : int,
+              CtrlKey : bool,
+              ShiftKey : bool,
+              AltKey : bool,
+              MetaKey : bool,
+              Buttons : { Left : bool, Right : bool, Middle : bool }
+       }
 
 con mouseEvents = map (fn _ :: Unit => mouseEvent -> transaction unit)
-                          [Onclick, Oncontextmenu, Ondblclick, Onmousedown, Onmouseenter, Onmouseleave, Onmousemove, Onmouseout, Onmouseover, Onmouseup]
+                          [Onclick, Oncontextmenu, Ondblclick, Onmousedown, Onmouseenter, Onmouseleave, Onmousemove, Onmouseout, Onmouseover, Onmouseup, Onpointerover, Onpointerenter, Onpointerdown, Onpointermove, Onpointerup, Onpointercancel, Onpointerout, Onpointerleave, Onpointerrawupdate, Ongotpointercapture, Onlostpointercapture]
 
 (* Key arguments are character codes. *)
 type keyEvent = { KeyCode : int,


### PR DESCRIPTION
This adds missing pointer events* and represents the button events more faithfully. Namely, several buttons can be pressed at once or none at all. The previous use of `event.button` was not safe.


\* Onpointerover, Onpointerenter, Onpointerdown, Onpointermove, Onpointerup, Onpointercancel, Onpointerout, Onpointerleave, Onpointerrawupdate, Ongotpointercapture, Onlostpointercapture