### PR TITLE
Add support for SQL `IS NOT NULL`

### DIFF
--- a/lib/ur/basis.urs
+++ b/lib/ur/basis.urs
@@ -545,6 +545,11 @@ val sql_is_null : tables ::: {{Type}} -> agg ::: {{Type}} -> exps ::: {Type}
                   -> sql_exp tables agg exps (option t)
                   -> sql_exp tables agg exps bool
 
+val sql_is_not_null : tables ::: {{Type}} -> agg ::: {{Type}} -> exps ::: {Type}
+                  -> t ::: Type
+                  -> sql_exp tables agg exps (option t)
+                  -> sql_exp tables agg exps bool
+
 val sql_coalesce : tables ::: {{Type}} -> agg ::: {{Type}} -> exps ::: {Type}
                   -> t ::: Type
                   -> sql_exp tables agg exps (option t)

--- a/src/monoize.sml
+++ b/src/monoize.sml
@@ -2741,6 +2741,24 @@ fun monoExp (env, st, fm) (all as (e, loc)) =
              (L.ECApp (
               (L.ECApp (
                (L.ECApp (
+                (L.EFfi ("Basis", "sql_is_not_null"), _), _),
+                _), _),
+               _), _),
+              _), _)) =>
+            let
+                val s = (L'.TFfi ("Basis", "string"), loc)
+            in
+                ((L'.EAbs ("s", s, s,
+                           strcat [str "(",
+                                   (L'.ERel 0, loc),
+                                   str " IS NOT NULL)"]), loc),
+                 fm)
+            end
+
+          | (L.ECApp (
+             (L.ECApp (
+              (L.ECApp (
+               (L.ECApp (
                 (L.EFfi ("Basis", "sql_coalesce"), _), _),
                 _), _),
                _), _),

--- a/src/urweb.grm
+++ b/src/urweb.grm
@@ -2193,6 +2193,12 @@ sqlexp : TRUE                           (sql_inject (EVar (["Basis"], "True", In
                                              (EApp ((EVar (["Basis"], "sql_is_null", Infer), loc),
                                                     sqlexp), loc)
                                          end)
+       | sqlexp IS NOT NULL             (let
+                                             val loc = s (sqlexpleft, NULLright)
+                                         in
+                                             (EApp ((EVar (["Basis"], "sql_is_not_null", Infer), loc),
+                                                    sqlexp), loc)
+                                         end)
 
        | CIF sqlexp CTHEN sqlexp CELSE sqlexp (let
                                                    val loc = s (CIFleft, sqlexp3right)


### PR DESCRIPTION
NB: without this patch, `NOT (e IS NULL)` still works, this is merely for convenience and compatibility with SQL